### PR TITLE
Replace on-state allowlist with off-state denylist for appliance state detection

### DIFF
--- a/custom_components/pv_excess_control/controller.py
+++ b/custom_components/pv_excess_control/controller.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+_OFF_STATES = {"off", "false", "False", "0"}
 _UNAVAILABLE_STATES = {"unavailable", "unknown", "none", ""}
 
 # Multipliers to normalise power values to watts.
@@ -179,7 +180,7 @@ class Controller:
             entity_state = self.hass.states.get(config.entity_id)
             is_on = False
             if entity_state is not None:
-                is_on = entity_state.state in ("on", "true", "True", "1")
+                is_on = entity_state.state not in _OFF_STATES and entity_state.state not in _UNAVAILABLE_STATES
 
             # Read actual power if available
             current_power = 0.0
@@ -250,7 +251,7 @@ class Controller:
             current_state = self.hass.states.get(config.entity_id)
             if not self._needs_change(decision, current_state, config):
                 entity_state = getattr(current_state, "state", None) if current_state else None
-                is_on = entity_state in ("on", "true", "True", "1") if entity_state else False
+                is_on = (entity_state not in _OFF_STATES and entity_state not in _UNAVAILABLE_STATES) if entity_state else False
                 _LOGGER.debug(
                     "Skip %s: already %s",
                     config.name, "on" if is_on else "off",
@@ -359,11 +360,11 @@ class Controller:
 
         if decision.action == Action.ON:
             # Already on - no change needed
-            if entity_state in ("on", "true", "True", "1"):
+            if entity_state not in _OFF_STATES and entity_state not in _UNAVAILABLE_STATES:
                 return False
         elif decision.action == Action.OFF:
             # Already off - no change needed
-            if entity_state in ("off", "false", "False", "0"):
+            if entity_state in _OFF_STATES:
                 return False
             # on_only prevents turning off
             if config.on_only:

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -125,6 +125,7 @@ from .planner import Planner
 
 _LOGGER = logging.getLogger(__name__)
 
+_OFF_STATES = {"off", "false", "False", "0"}
 _UNAVAILABLE_STATES = {STATE_UNAVAILABLE, STATE_UNKNOWN, "none", ""}
 
 # Maximum number of power history entries to keep (~30 min at 30s intervals)
@@ -969,7 +970,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_state = self.hass.states.get(config.entity_id)
             is_on = False
             if entity_state is not None:
-                is_on = entity_state.state in ("on", "true", "True", "1")
+                is_on = entity_state.state not in _OFF_STATES and entity_state.state not in _UNAVAILABLE_STATES
 
             # Detect off→on physical transition (Bug A from 2026-04-09
             # incident spec). activations_today is incremented based on
@@ -1056,7 +1057,8 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 entity_state = self.hass.states.get(entity_id) if entity_id else None
                 is_on = (
                     entity_state is not None
-                    and entity_state.state in ("on", "true", "True", "1")
+                    and entity_state.state not in _OFF_STATES
+                    and entity_state.state not in _UNAVAILABLE_STATES
                 )
 
                 # Refresh current_power from the actual power sensor
@@ -1259,7 +1261,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 continue
 
             # Check if state actually needs to change
-            is_on = current_state.state in ("on", "true", "True", "1")
+            is_on = current_state.state not in _OFF_STATES and current_state.state not in _UNAVAILABLE_STATES
             if decision.action == Action.ON and is_on:
                 _LOGGER.debug(
                     "Skipping %s for %s (%s): already on",
@@ -1544,7 +1546,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             current_state = self.hass.states.get(entity_id)
             if current_state is None:
                 continue
-            if current_state.state not in ("on", "true", "True", "1"):
+            if current_state.state in _OFF_STATES or current_state.state in _UNAVAILABLE_STATES:
                 continue
             domain = entity_id.split(".")[0] if "." in entity_id else "switch"
             name = subentry.data.get(CONF_APPLIANCE_NAME, subentry_id)


### PR DESCRIPTION
Fixes #9

Previously, appliances were considered "on" only if their state matched a hardcoded list of known on-states ("on", "true", "True", "1"). This caused climate and other multi-state entities to be incorrectly treated as off when in states like heat, cool, auto, fan_only, etc.

This PR inverts the logic: an appliance is considered on unless its state is explicitly off (_OFF_STATES) or unavailable (_UNAVAILABLE_STATES). This makes the detection open to any future states without code changes.
_parse_sensor_bool (used for binary sensors like EV connected status) is intentionally unchanged — allowlist semantics are correct there.