### PR TITLE
Feature/Enhancement: Allow positive off_threshold +  clarify text

### DIFF
--- a/custom_components/pv_excess_control/config_flow.py
+++ b/custom_components/pv_excess_control/config_flow.py
@@ -833,7 +833,7 @@ def _settings_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 default=d.get(CONF_OFF_THRESHOLD, DEFAULT_OFF_THRESHOLD),
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=-500, max=0, step=10, unit_of_measurement="W",
+                    min=-500, max=500, step=10, unit_of_measurement="W",
                     mode=NumberSelectorMode.BOX,
                 )
             ),

--- a/custom_components/pv_excess_control/strings.json
+++ b/custom_components/pv_excess_control/strings.json
@@ -132,7 +132,7 @@
         },
         "data_description": {
           "export_limit": "Maximum power allowed to export to the grid (0 = no limit).",
-          "off_threshold": "Grid draw (negative watts) tolerated before the optimizer starts shedding appliances. Default: -50 W.",
+          "off_threshold": "Export buffer before shedding appliances. Negative = tolerate some grid import (e.g. -50 W = shed only when importing more than 50 W). Positive = maintain a minimum export (e.g. 100 W = shed when grid export drops below 100 W). Default: -50 W.",
           "controller_interval": "How often the controller evaluates and adjusts appliances.",
           "planner_interval": "How often the planner recalculates the daily schedule.",
           "plan_influence": "Controls how the 24-hour planner influences real-time decisions. 'Light' lowers activation thresholds when the plan expects excess. 'Plan follows' actively schedules appliances based on forecast and tariff predictions. 'None' disables plan influence (pure reactive control).",
@@ -497,7 +497,7 @@
         },
         "data_description": {
           "export_limit": "Maximum power allowed to export to the grid (0 = no limit).",
-          "off_threshold": "Grid draw (negative watts) tolerated before the optimizer starts shedding appliances. Default: -50 W.",
+          "off_threshold": "Export buffer before shedding appliances. Negative = tolerate some grid import (e.g. -50 W = shed only when importing more than 50 W). Positive = maintain a minimum export (e.g. 100 W = shed when grid export drops below 100 W). Default: -50 W.",
           "controller_interval": "How often the controller evaluates and adjusts appliances.",
           "planner_interval": "How often the planner recalculates the daily schedule.",
           "plan_influence": "Controls how the 24-hour planner influences real-time decisions. 'Light' lowers activation thresholds when the plan expects excess. 'Plan follows' actively schedules appliances based on forecast and tariff predictions. 'None' disables plan influence (pure reactive control).",

--- a/custom_components/pv_excess_control/translations/en.json
+++ b/custom_components/pv_excess_control/translations/en.json
@@ -132,7 +132,7 @@
         },
         "data_description": {
           "export_limit": "Maximum power allowed to export to the grid (0 = no limit).",
-          "off_threshold": "Grid draw (negative watts) tolerated before the optimizer starts shedding appliances. Default: -50 W.",
+          "off_threshold": "Export buffer before shedding appliances. Negative = tolerate some grid import (e.g. -50 W = shed only when importing more than 50 W). Positive = maintain a minimum export (e.g. 100 W = shed when grid export drops below 100 W). Default: -50 W.",
           "controller_interval": "How often the controller evaluates and adjusts appliances.",
           "planner_interval": "How often the planner recalculates the daily schedule.",
           "plan_influence": "Controls how the 24-hour planner influences real-time decisions. 'Light' lowers activation thresholds when the plan expects excess. 'Plan follows' actively schedules appliances based on forecast and tariff predictions. 'None' disables plan influence (pure reactive control).",
@@ -497,7 +497,7 @@
         },
         "data_description": {
           "export_limit": "Maximum power allowed to export to the grid (0 = no limit).",
-          "off_threshold": "Grid draw (negative watts) tolerated before the optimizer starts shedding appliances. Default: -50 W.",
+          "off_threshold": "Export buffer before shedding appliances. Negative = tolerate some grid import (e.g. -50 W = shed only when importing more than 50 W). Positive = maintain a minimum export (e.g. 100 W = shed when grid export drops below 100 W). Default: -50 W.",
           "controller_interval": "How often the controller evaluates and adjusts appliances.",
           "planner_interval": "How often the planner recalculates the daily schedule.",
           "plan_influence": "Controls how the 24-hour planner influences real-time decisions. 'Light' lowers activation thresholds when the plan expects excess. 'Plan follows' actively schedules appliances based on forecast and tariff predictions. 'None' disables plan influence (pure reactive control).",


### PR DESCRIPTION
Increase the off_threshold NumberSelector max from 0 to 500 W so users can set positive export thresholds (previously limited to non-positive values). Update strings.json and translations/en.json to provide a clearer explanation of off_threshold semantics (negative = tolerate some grid import; positive = maintain a minimum export) with examples to reduce user confusion.

This is handy for peope who dont want any grid power at all or for people who's battery is not accessible from HA. Targetting 0-50W grid power, Will make the device never turn off cause the battery will keep it at zero; Withouth able to read it into HA, the appliance will suck the battery dry. If Set to positible value, like 50-100W. The device will kick of so there is stil a small amount of injection left. (Better sometimes than taking grid power)