### PR TITLE
fix: sync priority/runtime UI changes to coordinator without reload

### DIFF
--- a/custom_components/pv_excess_control/__init__.py
+++ b/custom_components/pv_excess_control/__init__.py
@@ -59,6 +59,11 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
             # Update the snapshot so future comparisons are correct
             domain_data[snapshot_key] = new_data
             domain_data[subentry_count_key] = new_subentry_count
+
+            # Sync the runtime cached values to pick up priority/runtime changes instantly
+            coordinator = domain_data.get(entry.entry_id)
+            if coordinator:
+                coordinator.update_from_subentries()
             return
 
     _LOGGER.info("Config entry updated (structural change), reloading integration")

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -1001,6 +1001,21 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             timestamp=datetime.now(),
         )
 
+    def update_from_subentries(self) -> None:
+        """Update runtime priorities and limits from subentries to reflect UI updates without reloading."""
+        subentries = getattr(self.config_entry, "subentries", {})
+        for subentry_id, subentry in subentries.items():
+            d = subentry.data
+            self.appliance_priorities[subentry_id] = d.get(CONF_APPLIANCE_PRIORITY, 500)
+            if CONF_MIN_DAILY_RUNTIME in d:
+                self.appliance_min_daily_runtime[subentry_id] = d[CONF_MIN_DAILY_RUNTIME]
+            else:
+                self.appliance_min_daily_runtime.pop(subentry_id, None)
+            if CONF_MAX_DAILY_RUNTIME in d:
+                self.appliance_max_daily_runtime[subentry_id] = d[CONF_MAX_DAILY_RUNTIME]
+            else:
+                self.appliance_max_daily_runtime.pop(subentry_id, None)
+
     # ------------------------------------------------------------------
     # Appliance configuration
     # ------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1490,6 +1490,114 @@ class TestPlannerInterval:
 
 
 # ---------------------------------------------------------------------------
+# Tests: update_from_subentries (sync UI changes without reload)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFromSubentries:
+    """update_from_subentries() must sync priority and runtime dicts from
+    subentry data so UI changes take effect without a full reload."""
+
+    def _make_entry_with_subentries(self, subentries_data: dict) -> MagicMock:
+        """Build a mock config entry whose subentries map matches subentries_data."""
+        entry = _make_config_entry()
+        subentries = {}
+        for sub_id, data in subentries_data.items():
+            sub = MagicMock()
+            sub.data = data
+            subentries[sub_id] = sub
+        entry.subentries = subentries
+        return entry
+
+    def test_priority_updated_from_subentry(self):
+        """update_from_subentries refreshes appliance_priorities from subentry data."""
+        from custom_components.pv_excess_control.const import CONF_APPLIANCE_PRIORITY
+
+        entry = self._make_entry_with_subentries({"sub1": {CONF_APPLIANCE_PRIORITY: 200}})
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_priorities = {"sub1": 500}  # stale value
+
+        coord.update_from_subentries()
+
+        assert coord.appliance_priorities["sub1"] == 200
+
+    def test_min_daily_runtime_updated_from_subentry(self):
+        """update_from_subentries refreshes appliance_min_daily_runtime."""
+        from custom_components.pv_excess_control.const import (
+            CONF_APPLIANCE_PRIORITY,
+            CONF_MIN_DAILY_RUNTIME,
+        )
+
+        entry = self._make_entry_with_subentries(
+            {"sub1": {CONF_APPLIANCE_PRIORITY: 300, CONF_MIN_DAILY_RUNTIME: 90}}
+        )
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_priorities = {"sub1": 300}
+        coord.appliance_min_daily_runtime = {}
+
+        coord.update_from_subentries()
+
+        assert coord.appliance_min_daily_runtime["sub1"] == 90
+
+    def test_min_daily_runtime_removed_when_absent(self):
+        """update_from_subentries pops min_daily_runtime when key is not in subentry."""
+        from custom_components.pv_excess_control.const import CONF_APPLIANCE_PRIORITY
+
+        entry = self._make_entry_with_subentries({"sub1": {CONF_APPLIANCE_PRIORITY: 300}})
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_min_daily_runtime = {"sub1": 60}  # stale
+
+        coord.update_from_subentries()
+
+        assert "sub1" not in coord.appliance_min_daily_runtime
+
+    def test_max_daily_runtime_updated_from_subentry(self):
+        """update_from_subentries refreshes appliance_max_daily_runtime."""
+        from custom_components.pv_excess_control.const import (
+            CONF_APPLIANCE_PRIORITY,
+            CONF_MAX_DAILY_RUNTIME,
+        )
+
+        entry = self._make_entry_with_subentries(
+            {"sub1": {CONF_APPLIANCE_PRIORITY: 300, CONF_MAX_DAILY_RUNTIME: 240}}
+        )
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_max_daily_runtime = {}
+
+        coord.update_from_subentries()
+
+        assert coord.appliance_max_daily_runtime["sub1"] == 240
+
+    def test_max_daily_runtime_removed_when_absent(self):
+        """update_from_subentries pops max_daily_runtime when key is not in subentry."""
+        from custom_components.pv_excess_control.const import CONF_APPLIANCE_PRIORITY
+
+        entry = self._make_entry_with_subentries({"sub1": {CONF_APPLIANCE_PRIORITY: 300}})
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_max_daily_runtime = {"sub1": 120}  # stale
+
+        coord.update_from_subentries()
+
+        assert "sub1" not in coord.appliance_max_daily_runtime
+
+    def test_multiple_subentries_all_updated(self):
+        """update_from_subentries processes every subentry."""
+        from custom_components.pv_excess_control.const import CONF_APPLIANCE_PRIORITY
+
+        entry = self._make_entry_with_subentries({
+            "sub1": {CONF_APPLIANCE_PRIORITY: 100},
+            "sub2": {CONF_APPLIANCE_PRIORITY: 800},
+        })
+        coord = _make_coordinator(entry=entry)
+        coord.appliance_priorities = {}
+
+        coord.update_from_subentries()
+
+        assert coord.appliance_priorities["sub1"] == 100
+        assert coord.appliance_priorities["sub2"] == 800
+
+
+# ---------------------------------------------------------------------------
 # Tests: async_setup_entry / async_unload_entry
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When a user edits an appliance's priority or min/max daily runtime in the HA UI, the change is silently ignored until the integration is fully reloaded — triggering a ~2-minute optimisation blackout.

**Root cause:** `_async_update_listener` correctly skips the reload for non-structural subentry changes, but the coordinator's cached `appliance_priorities` / `appliance_min_daily_runtime` / `appliance_max_daily_runtime` dicts are never refreshed from the updated subentry data, so the optimizer keeps running with stale values.

## Fix

Add `coordinator.update_from_subentries()` called from the non-structural branch of `_async_update_listener`. The method iterates the subentries and overwrites only the three cached dicts that need it; all other appliance config fields (deadline, preemption flag, grid supplement, etc.) are already read live from subentry data at each optimization cycle.

## Changes

- `coordinator.py`: add `update_from_subentries()` method
- `__init__.py`: call it from the update listener's skip-reload path
- `tests/test_init.py`: add `TestUpdateFromSubentries` (6 tests)

## No performance impact

`update_from_subentries()` is only called from the config-entry update listener (user edits in UI), never from the 30 s controller tick.