### PR TITLE
fix: prevent duplicate/orphaned entities on subentry add/remove

### DIFF
--- a/custom_components/pv_excess_control/__init__.py
+++ b/custom_components/pv_excess_control/__init__.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_time_change
 
 from .const import CONF_BATTERY_STRATEGY, DOMAIN
@@ -97,6 +98,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_track_time_change(hass, _midnight_reset, hour=0, minute=0, second=0)
     )
+
+    # Clean up orphaned entities from deleted subentries (appliances).
+    # Unique IDs have the form "<entry_id>_<subentry_id>_<suffix>"; both IDs are
+    # 26-char ULIDs, so we skip the entry_id itself to avoid deleting system entities.
+    ent_reg = er.async_get(hass)
+    active_subentry_ids = set(getattr(entry, "subentries", {}).keys())
+    for reg_entry in er.async_entries_for_config_entry(ent_reg, entry.entry_id):
+        parts = reg_entry.unique_id.split("_")
+        for part in parts:
+            if len(part) == 26 and part != entry.entry_id and part not in active_subentry_ids:
+                _LOGGER.info("Removing orphaned entity %s", reg_entry.entity_id)
+                ent_reg.async_remove(reg_entry.entity_id)
+                break
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/pv_excess_control/binary_sensor.py
+++ b/custom_components/pv_excess_control/binary_sensor.py
@@ -29,17 +29,18 @@ async def async_setup_entry(
     """Set up PV Excess Control binary sensor entities."""
     coordinator: PvExcessCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[BinarySensorEntity] = [
+    # System-level binary sensors (no subentry association)
+    async_add_entities([
         ExcessAvailableBinarySensor(coordinator),
-    ]
+    ])
 
     # Per-appliance active sensors
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
         appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(ApplianceActiveBinarySensor(coordinator, subentry_id, appliance_name))
-
-    async_add_entities(entities)
+        async_add_entities([
+            ApplianceActiveBinarySensor(coordinator, subentry_id, appliance_name),
+        ], config_subentry_id=subentry_id)
 
 
 class _PvExcessBinarySensorBase(
@@ -118,6 +119,7 @@ class ApplianceActiveBinarySensor(_PvExcessBinarySensorBase):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_active"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/pv_excess_control/number.py
+++ b/custom_components/pv_excess_control/number.py
@@ -38,11 +38,11 @@ async def async_setup_entry(
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
         appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(AppliancePriorityNumber(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceMinDailyRuntimeNumber(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceMaxDailyRuntimeNumber(coordinator, subentry_id, appliance_name))
-
-    async_add_entities(entities)
+        async_add_entities([
+            AppliancePriorityNumber(coordinator, subentry_id, appliance_name),
+            ApplianceMinDailyRuntimeNumber(coordinator, subentry_id, appliance_name),
+            ApplianceMaxDailyRuntimeNumber(coordinator, subentry_id, appliance_name),
+        ], config_subentry_id=subentry_id)
 
 
 class AppliancePriorityNumber(CoordinatorEntity[PvExcessCoordinator], NumberEntity):
@@ -68,6 +68,7 @@ class AppliancePriorityNumber(CoordinatorEntity[PvExcessCoordinator], NumberEnti
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_priority"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -133,6 +134,7 @@ class ApplianceMinDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], Num
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_min_daily_runtime"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -220,6 +222,7 @@ class ApplianceMaxDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], Num
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_max_daily_runtime"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/pv_excess_control/sensor.py
+++ b/custom_components/pv_excess_control/sensor.py
@@ -44,24 +44,23 @@ async def async_setup_entry(
     """Set up PV Excess Control sensor entities from a config entry."""
     coordinator: PvExcessCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[SensorEntity] = [
+    # System-level sensors (no subentry association)
+    async_add_entities([
         PvExcessPowerSensor(coordinator),
         PvPlanConfidenceSensor(coordinator),
-    ]
+    ])
 
     # Per-appliance sensors from subentries
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
         appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.extend([
+        async_add_entities([
             PvAppliancePowerSensor(coordinator, subentry_id, appliance_name),
             PvApplianceRuntimeSensor(coordinator, subentry_id, appliance_name),
             PvApplianceEnergySensor(coordinator, subentry_id, appliance_name),
             PvApplianceActivationsSensor(coordinator, subentry_id, appliance_name),
             PvApplianceStatusSensor(coordinator, subentry_id, appliance_name),
-        ])
-
-    async_add_entities(entities)
+        ], config_subentry_id=subentry_id)
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +192,7 @@ class PvApplianceBaseSensor(PvExcessBaseSensor):
         name = f"{appliance_name} {sensor_label}"
         super().__init__(coordinator, unique_id_suffix, name)
         self._appliance_id = appliance_id
+        self._attr_config_subentry_id = appliance_id
 
     def _appliance_state(self):
         """Return the ApplianceState for this appliance, or None."""

--- a/custom_components/pv_excess_control/switch.py
+++ b/custom_components/pv_excess_control/switch.py
@@ -25,19 +25,20 @@ async def async_setup_entry(
     """Set up PV Excess Control switch entities."""
     coordinator: PvExcessCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities: list[SwitchEntity] = [
+    # System-level switches (no subentry association)
+    async_add_entities([
         ControlEnabledSwitch(coordinator),
         ForceChargeSwitch(coordinator),
-    ]
+    ])
 
     # Per-appliance switches
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
         appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(ApplianceEnabledSwitch(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceOverrideSwitch(coordinator, subentry_id, appliance_name))
-
-    async_add_entities(entities)
+        async_add_entities([
+            ApplianceEnabledSwitch(coordinator, subentry_id, appliance_name),
+            ApplianceOverrideSwitch(coordinator, subentry_id, appliance_name),
+        ], config_subentry_id=subentry_id)
 
 
 class _PvExcessSwitchBase(CoordinatorEntity[PvExcessCoordinator], SwitchEntity):
@@ -155,6 +156,7 @@ class ApplianceEnabledSwitch(_PvExcessSwitchBase):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_enabled"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def is_on(self) -> bool:
@@ -208,6 +210,7 @@ class ApplianceOverrideSwitch(_PvExcessSwitchBase):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_{appliance_id}_override"
         )
+        self._attr_config_subentry_id = appliance_id
 
     @property
     def is_on(self) -> bool:

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -890,9 +890,9 @@ class TestNumberEntities:
             async_setup_entry,
         )
 
-        added: list = []
-        def _add(entities, update_before_add=False):
-            added.extend(entities)
+        added: list[tuple] = []  # (entities, subentry_id)
+        def _add(entities, update_before_add=False, config_subentry_id=None):
+            added.append((list(entities), config_subentry_id))
 
         hass = MagicMock()
         coord = _make_coordinator()
@@ -906,11 +906,16 @@ class TestNumberEntities:
 
         await async_setup_entry(hass, config_entry, _add)
 
-        classes = {type(e) for e in added}
+        all_entities = [e for entities, _ in added for e in entities]
+        classes = {type(e) for e in all_entities}
         assert AppliancePriorityNumber in classes
         assert ApplianceMinDailyRuntimeNumber in classes
         assert ApplianceMaxDailyRuntimeNumber in classes
-        assert len(added) == 3
+        assert len(all_entities) == 3
+        # Per-appliance entities must be registered under their subentry
+        subentry_calls = [(entities, sid) for entities, sid in added if sid == "app_1"]
+        assert len(subentry_calls) == 1
+        assert len(subentry_calls[0][0]) == 3
 
 
 # ---------------------------------------------------------------------------
@@ -1075,3 +1080,60 @@ class TestSelectEntities:
         coord = _make_coordinator()
         sel = BatteryStrategySelect(coord)
         assert sel.name == "Battery Strategy"
+
+
+# ---------------------------------------------------------------------------
+# Subentry association tests
+# ---------------------------------------------------------------------------
+
+class TestSubentryAssociation:
+    """Per-appliance entities must carry _attr_config_subentry_id so HA ties
+    them to the correct subentry (and removes them when it is deleted)."""
+
+    def test_appliance_switch_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.switch import ApplianceEnabledSwitch
+        coord = _make_coordinator()
+        sw = ApplianceEnabledSwitch(coord, "sub_abc", "Pump")
+        assert sw._attr_config_subentry_id == "sub_abc"
+
+    def test_appliance_override_switch_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.switch import ApplianceOverrideSwitch
+        coord = _make_coordinator()
+        sw = ApplianceOverrideSwitch(coord, "sub_abc", "Pump")
+        assert sw._attr_config_subentry_id == "sub_abc"
+
+    def test_system_switch_has_no_config_subentry_id(self):
+        from custom_components.pv_excess_control.switch import ControlEnabledSwitch
+        coord = _make_coordinator()
+        sw = ControlEnabledSwitch(coord)
+        assert getattr(sw, "_attr_config_subentry_id", None) is None
+
+    def test_priority_number_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.number import AppliancePriorityNumber
+        coord = _make_coordinator()
+        n = AppliancePriorityNumber(coord, "sub_abc", "Pump")
+        assert n._attr_config_subentry_id == "sub_abc"
+
+    def test_min_runtime_number_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.number import ApplianceMinDailyRuntimeNumber
+        coord = _make_coordinator()
+        n = ApplianceMinDailyRuntimeNumber(coord, "sub_abc", "Pump")
+        assert n._attr_config_subentry_id == "sub_abc"
+
+    def test_max_runtime_number_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.number import ApplianceMaxDailyRuntimeNumber
+        coord = _make_coordinator()
+        n = ApplianceMaxDailyRuntimeNumber(coord, "sub_abc", "Pump")
+        assert n._attr_config_subentry_id == "sub_abc"
+
+    def test_appliance_active_sensor_has_config_subentry_id(self):
+        from custom_components.pv_excess_control.binary_sensor import ApplianceActiveBinarySensor
+        coord = _make_coordinator()
+        bs = ApplianceActiveBinarySensor(coord, "sub_abc", "Pump")
+        assert bs._attr_config_subentry_id == "sub_abc"
+
+    def test_excess_binary_sensor_has_no_config_subentry_id(self):
+        from custom_components.pv_excess_control.binary_sensor import ExcessAvailableBinarySensor
+        coord = _make_coordinator()
+        bs = ExcessAvailableBinarySensor(coord)
+        assert getattr(bs, "_attr_config_subentry_id", None) is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1583,6 +1583,89 @@ class TestSetupAndUnload:
 
 
 # ---------------------------------------------------------------------------
+# Tests: orphaned entity cleanup on setup
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedEntityCleanup:
+    """async_setup_entry must remove entities whose subentry no longer exists
+    without touching system-level entities or active-subentry entities.
+
+    Uses a fully-mocked hass + coordinator to isolate the registry logic from
+    HA infrastructure (storage, event loop timers, etc.).
+    """
+
+    def _make_reg_entry(self, unique_id: str) -> MagicMock:
+        e = MagicMock()
+        e.unique_id = unique_id
+        e.entity_id = f"sensor.{unique_id}"
+        return e
+
+    async def _run_setup(self, entry_id, subentries, reg_entries):
+        """Call async_setup_entry with everything mocked except the er cleanup."""
+        from custom_components.pv_excess_control import async_setup_entry
+        from homeassistant.helpers import entity_registry as er
+
+        entry = MagicMock()
+        entry.entry_id = entry_id
+        entry.subentries = subentries
+        entry.data = {}
+        entry.add_update_listener = MagicMock(return_value=MagicMock())
+        entry.async_on_unload = MagicMock()
+
+        hass = MagicMock()
+        hass.data = {}
+
+        mock_coord = MagicMock()
+        mock_coord.async_config_entry_first_refresh = AsyncMock()
+        mock_ent_reg = MagicMock()
+
+        with patch("custom_components.pv_excess_control.PvExcessCoordinator", return_value=mock_coord), \
+             patch("custom_components.pv_excess_control.async_track_time_change", return_value=MagicMock()), \
+             patch.object(hass.config_entries, "async_forward_entry_setups", new_callable=AsyncMock), \
+             patch.object(er, "async_get", return_value=mock_ent_reg), \
+             patch.object(er, "async_entries_for_config_entry", return_value=reg_entries):
+            await async_setup_entry(hass, entry)
+
+        return mock_ent_reg
+
+    @pytest.mark.asyncio
+    async def test_orphaned_appliance_entity_is_removed(self):
+        """Entity whose unique_id contains a stale subentry ID is removed."""
+        entry_id = "a" * 26
+        stale_reg = self._make_reg_entry(f"{'a'*26}_{'b'*26}_priority")
+        mock_ent_reg = await self._run_setup(entry_id, subentries={}, reg_entries=[stale_reg])
+        mock_ent_reg.async_remove.assert_called_once_with(stale_reg.entity_id)
+
+    @pytest.mark.asyncio
+    async def test_system_entity_is_not_removed(self):
+        """System entity unique_id = '<entry_id>_battery_strategy' is preserved.
+
+        entry_id is also 26 chars, so the old check (len == 26) would have
+        incorrectly matched it. The fix adds `part != entry.entry_id`.
+        """
+        entry_id = "a" * 26
+        system_reg = self._make_reg_entry(f"{'a'*26}_battery_strategy")
+        mock_ent_reg = await self._run_setup(entry_id, subentries={}, reg_entries=[system_reg])
+        mock_ent_reg.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_active_appliance_entity_is_not_removed(self):
+        """Entity whose subentry_id is still active is preserved."""
+        entry_id = "a" * 26
+        active_subentry_id = "c" * 26
+        subentry = MagicMock()
+        subentry.data = {"appliance_name": "Pump"}
+        active_reg = self._make_reg_entry(f"{'a'*26}_{'c'*26}_enabled")
+        mock_ent_reg = await self._run_setup(
+            entry_id,
+            subentries={active_subentry_id: subentry},
+            reg_entries=[active_reg],
+        )
+        mock_ent_reg.async_remove.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Tests: full update cycle (integration-style)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Two related entity-lifecycle bugs when appliances (subentries) are added or deleted:

1. **Orphaned entities persist across restarts.** Entities from deleted subentries remain in the HA entity registry because they were never associated with their subentry — HA can't clean them up automatically.

2. **Duplicate entities appear on reload.** Without `config_subentry_id` set, HA treats all entities as belonging to the root config entry, causing duplicates when the integration reloads after a structural change.

## Fix

**Subentry association** — pass `config_subentry_id=subentry_id` to `async_add_entities()` and set `_attr_config_subentry_id` on each per-appliance entity across all platforms (`switch`, `number`, `binary_sensor`, `sensor`). This lets HA manage the entity lifecycle automatically going forward.

**Migration cleanup** — at `async_setup_entry` time, scan the entity registry for any registered entity whose `unique_id` contains a 26-char ULID that is neither the config entry ID nor an active subentry ID, and remove it. This cleans up entities that were registered before this fix without requiring a manual entity deletion.

The entry ID exclusion (`part != entry.entry_id`) is critical: both the config entry ID and subentry IDs are 26-char ULIDs, so omitting it would delete all system-level entities (battery_strategy, control_enabled, etc.) on every restart.

## Changes

- `__init__.py`: orphaned entity cleanup at setup + `er` import moved to module level
- `binary_sensor.py`, `number.py`, `sensor.py`, `switch.py`: `config_subentry_id` association
- `tests/test_entities.py`: fix broken `_add` mock, add `TestSubentryAssociation` (8 tests)
- `tests/test_init.py`: add `TestOrphanedEntityCleanup` (3 tests)