### PR TITLE
feat: persist daily state, add global on-threshold config, and fix EV override budgeting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,117 @@
+---
+minimum_pre_commit_version: "3.6.0"
+
+ci:
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autofix_commit_msg: "style: apply pre-commit fixes"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+        args:
+          - --maxkb=1000
+
+      - id: check-case-conflict
+
+      - id: check-executables-have-shebangs
+        stages:
+          - manual
+
+      - id: check-json
+        exclude: ^(?:\.vscode|\.devcontainer)/
+
+      - id: check-merge-conflict
+
+      - id: check-toml
+
+      - id: check-yaml
+        args:
+          - --unsafe
+
+      - id: debug-statements
+
+      - id: detect-private-key
+
+      - id: end-of-file-fixer
+
+      - id: mixed-line-ending
+        args:
+          - --fix=lf
+
+      - id: trailing-whitespace
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+
+      - id: ruff-format
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+      - id: codespell
+        args:
+          - --ignore-words-list=fro,hass
+          - --skip=./.*,*.csv,*.json,*.ambr
+          - --quiet-level=2
+        exclude_types:
+          - csv
+          - json
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        exclude: ^(?:\.github|\.vscode|\.devcontainer)/
+
+  # The official mirrors-prettier repository is archived.
+  # Prettier is therefore installed directly as an isolated Node dependency.
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: prettier --write --ignore-unknown
+        language: node
+        additional_dependencies:
+          - prettier@3.6.2
+        types_or:
+          - css
+          - html
+          - javascript
+          - json
+          - markdown
+          - yaml
+
+  # Run manually when modernizing type annotations:
+  #
+  # pre-commit run --hook-stage manual python-typing-update --all-files
+  #
+  # This hook can require manual follow-up work.
+  - repo: https://github.com/cdce8p/python-typing-update
+    rev: v0.8.1
+    hooks:
+      - id: python-typing-update
+        stages:
+          - manual
+        args:
+          - --py311-plus
+          - --force
+          - --keep-updates
+        types:
+          - python
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      - id: mypy
+        stages:
+          - manual
+        args:
+          - --ignore-missing-imports
+        types:
+          - python

--- a/README.de.md
+++ b/README.de.md
@@ -2,7 +2,7 @@
 
 # PV Excess Control
 
-*Hinweis: Diese Übersetzung kann der englischen Version hinterherhinken — die [englische README](README.md) ist die maßgebliche Version.*
+_Hinweis: Diese Übersetzung kann der englischen Version hinterherhinken — die [englische README](README.md) ist die maßgebliche Version._
 
 **Eine umfassende Home Assistant-Integration für intelligente Solarüberschuss-Optimierung und günstige Netztarif-Verwaltung.**
 
@@ -23,6 +23,7 @@ Diese Integration ist Open Source, weil ich daran glaube, der Community, die Hom
 ## Funktionen
 
 ### Optimierung & Planung
+
 - **Smarte Planung** - 24-Stunden vorausschauender Optimierungsalgorithmus mit wetterabhängiger Vorplanung und konfigurierbarem Planeinfluss.
 - **Prioritätsbasierte Gerätesteuerung** - Verwaltung mehrerer Geräte mit konfigurierbaren Prioritäten (1-1000).
 - **Opportunitätskosten** - Berücksichtigung der entgangenen Einspeisevergütung
@@ -30,6 +31,7 @@ Diese Integration ist Open Source, weil ich daran glaube, der Community, die Hom
 - **Min/Max Laufzeit & Zeitfenster** - Zeitbeschränkungen für einzelne Geräte
 
 ### E-Auto & Batteriemanagement
+
 - **SoC-basiertes E-Auto Laden** - Berücksichtigt den Batteriestand des E-Autos und den Verbindungsstatus
 - **Zeitplan-Fristen** - Setzen von Bedingungen wie bspw. "E-Auto muss bis 7 Uhr geladen sein".
 - **Dynamische Stromsteuerung** - Variable Ampere-Regelung für E-Auto-Ladegeräte und Wallboxen (6-32 A).
@@ -38,11 +40,13 @@ Diese Integration ist Open Source, weil ich daran glaube, der Community, die Hom
 - **Batterieentladeschutz** - Begrenzt die Entladerate, wenn große Verbraucher laufen.
 
 ### Stromtarife & -netz
+
 - **Tarif-Integration** - Unterstützung für Tibber, Awattar, Nordpool, Octopus Energy und generische Preissensoren.
 - **Einspeiselimit-Management** - Absorbieren potenziell abgeregelter Leistung möglich, z.B. wenn Einspeisebegrenzungen gelten.
 - **Netzsupplementierung** - Möglichkeit, eine bestimmte Menge an Netzstrom zu erlauben, um Geräte zusätzlich zu supplementieren.
 
 ### UI, Analyse & Integrationen
+
 - **Solarprognose-Integration** - Solcast, Forecast.Solar und generische Prognosesensoren.
 - **Umfangreiche Dashboard-Beispiele** — Erstelle dein eigenes Dashboard mit Mushroom, ApexCharts und anderen Community-Karten. [Vollständige YAML-Beispiele enthalten](docs/dashboard-examples.md).
 - **Eigenverbrauchs-Analyse** - Verfolgen von Einsparungen, Eigenverbrauchsquote, Energiestatistiken.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-ea4aaa)](https://github.com/sponsors/InventoCasa)
 [![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-%E2%98%95-FFDD00)](https://buymeacoffee.com/henrikic)
 
-
 ## About
 
 PV Excess Control is built and maintained by Henrik Wasserfuhr, founder of [**InventoCasa**](https://inventocasa.de). We are specialized smart home integrators, designing and deploying complete Home Assistant environments for new builds, renovations, and retrofits.
@@ -23,6 +22,7 @@ This integration is open source because I believe in giving back to the communit
 ## Features
 
 ### Core Optimization & Planning
+
 - **Smart Planning** - 24-hour forward-looking optimizer with weather-aware pre-planning and configurable plan influence.
 - **Priority-Based Appliance Control** - Manage multiple appliances with configurable priorities (1-1000).
 - **Opportunity Cost** - Factors in feed-in tariff revenue when making decisions.
@@ -31,6 +31,7 @@ This integration is open source because I believe in giving back to the communit
 - **Min/Max Runtime & Time Windows** - Ensure appliances run for required durations and restrict them to specific hours.
 
 ### EV & Battery Management
+
 - **EV SoC-Aware Charging** - Considers EV battery level, connection status, and user-defined targets.
 - **Schedule Deadlines** - Set constraints like "EV must be charged by 7am".
 - **Dynamic Current Control** - Variable amperage for EV chargers and wallboxes (6-32 A).
@@ -39,11 +40,13 @@ This integration is open source because I believe in giving back to the communit
 - **Battery Discharge Protection** - Limit discharge rate when big consumers are running.
 
 ### Tariffs & Grid
+
 - **Tariff Integration** - Support for Tibber, Awattar, Nordpool, Octopus Energy, and generic price sensors.
 - **Export Limit Management** - Absorb would-be-curtailed power when feed-in caps apply.
 - **Grid Supplementation** - Allow a small amount of grid power to top up appliances.
 
 ### UI, Analytics & Integrations
+
 - **Solar Forecast Integration** - Solcast, Forecast.Solar, and generic forecast sensors.
 - **Extensive Dashboard Examples** — Build your own dashboard with Mushroom, ApexCharts and other community cards. [Full YAML examples included](docs/dashboard-examples.md).
 - **Self-Consumption Analytics** - Track savings, self-consumption ratio, energy statistics.
@@ -134,12 +137,12 @@ pip install -r requirements_test.txt
 python3 -m pytest tests/ --ignore=tests/playwright --ignore=tests/ha_integration_test.py
 ```
 
-
 ## License
 
 This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)** - see the [LICENSE](LICENSE) file for details.
 
 **What this means:**
+
 - **Personal use** - fully free, no restrictions
 - **Commercial use** - if you integrate this into a product or service, you must open-source your entire work under AGPL-3.0
 - **Commercial licensing** - for proprietary/commercial use without the AGPL obligations, [contact InventoCasa](https://inventocasa.de/kontakt/) for a commercial license

--- a/custom_components/pv_excess_control/__init__.py
+++ b/custom_components/pv_excess_control/__init__.py
@@ -1,4 +1,5 @@
 """The PV Excess Control integration."""
+
 from __future__ import annotations
 
 import logging
@@ -23,11 +24,16 @@ PLATFORMS: list[Platform] = [
 
 # Keys that represent runtime state (toggled via switches/selects).
 # Changes to ONLY these keys should NOT trigger a full integration reload.
-_RUNTIME_STATE_KEYS = frozenset({
-    "control_enabled", "force_charge", CONF_BATTERY_STRATEGY,
-    "disabled_appliances", "overridden_appliances",
-    "_grid_charge_engaged",
-})
+_RUNTIME_STATE_KEYS = frozenset(
+    {
+        "control_enabled",
+        "force_charge",
+        CONF_BATTERY_STRATEGY,
+        "disabled_appliances",
+        "overridden_appliances",
+        "_grid_charge_engaged",
+    }
+)
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -45,17 +51,22 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     if old_snapshot is not None:
         new_data = dict(entry.data)
         # Compare data excluding runtime-state keys
-        old_structural = {k: v for k, v in old_snapshot.items() if k not in _RUNTIME_STATE_KEYS}
-        new_structural = {k: v for k, v in new_data.items() if k not in _RUNTIME_STATE_KEYS}
+        old_structural = {
+            k: v for k, v in old_snapshot.items() if k not in _RUNTIME_STATE_KEYS
+        }
+        new_structural = {
+            k: v for k, v in new_data.items() if k not in _RUNTIME_STATE_KEYS
+        }
 
         # Also check if subentry count changed (subentry add/remove)
         old_subentry_count = domain_data.get(subentry_count_key, 0)
         new_subentry_count = len(getattr(entry, "subentries", {}))
 
-        if old_structural == new_structural and old_subentry_count == new_subentry_count:
-            _LOGGER.debug(
-                "Config entry updated (runtime state only), skipping reload"
-            )
+        if (
+            old_structural == new_structural
+            and old_subentry_count == new_subentry_count
+        ):
+            _LOGGER.debug("Config entry updated (runtime state only), skipping reload")
             # Update the snapshot so future comparisons are correct
             domain_data[snapshot_key] = new_data
             domain_data[subentry_count_key] = new_subentry_count
@@ -68,6 +79,7 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PV Excess Control from a config entry."""
     coordinator = PvExcessCoordinator(hass, entry)
+    await coordinator.async_restore_daily_state()
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
@@ -75,7 +87,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store a snapshot of config data so the update listener can detect
     # whether a change is structural (needs reload) or runtime-only.
     hass.data[DOMAIN][f"{entry.entry_id}_config_snapshot"] = dict(entry.data)
-    hass.data[DOMAIN][f"{entry.entry_id}_subentry_count"] = len(getattr(entry, "subentries", {}))
+    hass.data[DOMAIN][f"{entry.entry_id}_subentry_count"] = len(
+        getattr(entry, "subentries", {})
+    )
 
     # Listen for config/subentry changes and reload when they happen
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -92,6 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         except Exception:
             _LOGGER.exception("Failed to send daily summary notification")
         coordinator.reset_daily()
+        await coordinator.async_save_daily_state()
         await coordinator.async_request_refresh()
 
     entry.async_on_unload(
@@ -105,6 +120,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is not None:
+        await coordinator.async_save_daily_state()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id, None)

--- a/custom_components/pv_excess_control/analytics.py
+++ b/custom_components/pv_excess_control/analytics.py
@@ -86,7 +86,11 @@ class AnalyticsTracker:
         self._total_savings += max(savings, 0.0)
         _LOGGER.debug(
             "Analytics: %s %.1fW for %ds source=%s savings=%.4f",
-            appliance_id, power_watts, duration_seconds, source, max(savings, 0.0),
+            appliance_id,
+            power_watts,
+            duration_seconds,
+            source,
+            max(savings, 0.0),
         )
 
     def record_solar_production(

--- a/custom_components/pv_excess_control/binary_sensor.py
+++ b/custom_components/pv_excess_control/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for PV Excess Control."""
+
 from __future__ import annotations
 
 import logging
@@ -36,8 +37,12 @@ async def async_setup_entry(
     # Per-appliance active sensors
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
-        appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(ApplianceActiveBinarySensor(coordinator, subentry_id, appliance_name))
+        appliance_name = subentry.data.get(
+            CONF_APPLIANCE_NAME, f"Appliance {subentry_id}"
+        )
+        entities.append(
+            ApplianceActiveBinarySensor(coordinator, subentry_id, appliance_name)
+        )
 
     async_add_entities(entities)
 
@@ -89,11 +94,7 @@ class ExcessAvailableBinarySensor(_PvExcessBinarySensorBase):
             return power_state.excess_power > EXCESS_AVAILABLE_THRESHOLD
         # Use averaged excess from history to smooth out transient spikes.
         # Skip None samples (sensor was unavailable that cycle).
-        good = [
-            ps.excess_power
-            for ps in history
-            if ps.excess_power is not None
-        ]
+        good = [ps.excess_power for ps in history if ps.excess_power is not None]
         if not good:
             return False
         avg_excess = sum(good) / len(good)

--- a/custom_components/pv_excess_control/config_flow.py
+++ b/custom_components/pv_excess_control/config_flow.py
@@ -10,6 +10,7 @@ Multi-step config flow that collects:
 
 Also provides ApplianceSubentryFlow for managing appliances as subentries.
 """
+
 from __future__ import annotations
 
 import logging
@@ -130,15 +131,14 @@ from .const import (
     DEFAULT_CONTROLLER_INTERVAL,
     DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
     DEFAULT_GRID_VOLTAGE,
+    DEFAULT_ON_THRESHOLD,
     DEFAULT_OFF_THRESHOLD,
     DEFAULT_PLANNER_INTERVAL,
     DEFAULT_SWITCH_INTERVAL,
     DOMAIN,
     MAX_CURRENT,
-    MAX_PHASES,
     MAX_PRIORITY,
     MIN_CURRENT,
-    MIN_PHASES,
     MIN_PRIORITY,
     BatteryStrategy,
     ForecastProvider,
@@ -529,10 +529,12 @@ def _appliance_constraints_schema(
             {"value": aid, "label": aname}
             for aid, aname in available_appliances.items()
         ]
-        schema_dict[vol.Optional(
-            CONF_REQUIRES_APPLIANCE,
-            description={"suggested_value": d.get(CONF_REQUIRES_APPLIANCE, "")},
-        )] = SelectSelector(
+        schema_dict[
+            vol.Optional(
+                CONF_REQUIRES_APPLIANCE,
+                description={"suggested_value": d.get(CONF_REQUIRES_APPLIANCE, "")},
+            )
+        ] = SelectSelector(
             SelectSelectorConfig(options=options, mode=SelectSelectorMode.DROPDOWN)
         )
 
@@ -548,22 +550,58 @@ def _sensor_schema(
     """
     d = defaults or {}
     schema_dict: dict[vol.Marker, Any] = {
-        vol.Required(CONF_PV_POWER, description={"suggested_value": d.get(CONF_PV_POWER)}): SENSOR_ENTITY_SELECTOR,
-        vol.Optional(CONF_GRID_EXPORT, description={"suggested_value": d.get(CONF_GRID_EXPORT)}): SENSOR_ENTITY_SELECTOR,
-        vol.Optional(CONF_IMPORT_EXPORT, description={"suggested_value": d.get(CONF_IMPORT_EXPORT)}): SENSOR_ENTITY_SELECTOR,
-        vol.Optional(CONF_LOAD_POWER, description={"suggested_value": d.get(CONF_LOAD_POWER)}): SENSOR_ENTITY_SELECTOR,
+        vol.Required(
+            CONF_PV_POWER, description={"suggested_value": d.get(CONF_PV_POWER)}
+        ): SENSOR_ENTITY_SELECTOR,
+        vol.Optional(
+            CONF_GRID_EXPORT, description={"suggested_value": d.get(CONF_GRID_EXPORT)}
+        ): SENSOR_ENTITY_SELECTOR,
+        vol.Optional(
+            CONF_IMPORT_EXPORT,
+            description={"suggested_value": d.get(CONF_IMPORT_EXPORT)},
+        ): SENSOR_ENTITY_SELECTOR,
+        vol.Optional(
+            CONF_LOAD_POWER, description={"suggested_value": d.get(CONF_LOAD_POWER)}
+        ): SENSOR_ENTITY_SELECTOR,
     }
 
     if is_hybrid:
-        schema_dict[vol.Required(CONF_BATTERY_SOC, description={"suggested_value": d.get(CONF_BATTERY_SOC)})] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Required(
+                CONF_BATTERY_SOC,
+                description={"suggested_value": d.get(CONF_BATTERY_SOC)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
         # Battery power: either combined (positive=charging, negative=discharging)
         # or separate charge/discharge sensors — same pattern as grid import/export
-        schema_dict[vol.Optional(CONF_BATTERY_POWER, description={"suggested_value": d.get(CONF_BATTERY_POWER)})] = SENSOR_ENTITY_SELECTOR
-        schema_dict[vol.Optional(CONF_BATTERY_CHARGE_POWER, description={"suggested_value": d.get(CONF_BATTERY_CHARGE_POWER)})] = SENSOR_ENTITY_SELECTOR
-        schema_dict[vol.Optional(CONF_BATTERY_DISCHARGE_POWER, description={"suggested_value": d.get(CONF_BATTERY_DISCHARGE_POWER)})] = SENSOR_ENTITY_SELECTOR
-        schema_dict[vol.Required(CONF_BATTERY_CAPACITY, default=d.get(CONF_BATTERY_CAPACITY, 10.0))] = NumberSelector(
+        schema_dict[
+            vol.Optional(
+                CONF_BATTERY_POWER,
+                description={"suggested_value": d.get(CONF_BATTERY_POWER)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Optional(
+                CONF_BATTERY_CHARGE_POWER,
+                description={"suggested_value": d.get(CONF_BATTERY_CHARGE_POWER)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Optional(
+                CONF_BATTERY_DISCHARGE_POWER,
+                description={"suggested_value": d.get(CONF_BATTERY_DISCHARGE_POWER)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Required(
+                CONF_BATTERY_CAPACITY, default=d.get(CONF_BATTERY_CAPACITY, 10.0)
+            )
+        ] = NumberSelector(
             NumberSelectorConfig(
-                min=0.1, max=1000, step=0.1, unit_of_measurement="kWh",
+                min=0.1,
+                max=1000,
+                step=0.1,
+                unit_of_measurement="kWh",
                 mode=NumberSelectorMode.BOX,
             )
         )
@@ -593,43 +631,60 @@ def _energy_schema(
     }
 
     if tariff_provider != TariffProvider.NONE:
-        schema_dict[vol.Required(CONF_PRICE_SENSOR, description={"suggested_value": d.get(CONF_PRICE_SENSOR)})] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Required(
+                CONF_PRICE_SENSOR,
+                description={"suggested_value": d.get(CONF_PRICE_SENSOR)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
 
-    schema_dict[vol.Optional(
-        CONF_CHEAP_PRICE_THRESHOLD,
-        description={"suggested_value": d.get(CONF_CHEAP_PRICE_THRESHOLD)},
-    )] = NumberSelector(
+    schema_dict[
+        vol.Optional(
+            CONF_CHEAP_PRICE_THRESHOLD,
+            description={"suggested_value": d.get(CONF_CHEAP_PRICE_THRESHOLD)},
+        )
+    ] = NumberSelector(
         NumberSelectorConfig(
-            min=0, max=1000, step=0.01,
+            min=0,
+            max=1000,
+            step=0.01,
             mode=NumberSelectorMode.BOX,
         )
     )
-    schema_dict[vol.Optional(
-        CONF_BATTERY_CHARGE_PRICE_THRESHOLD,
-        description={"suggested_value": d.get(CONF_BATTERY_CHARGE_PRICE_THRESHOLD)},
-    )] = NumberSelector(
+    schema_dict[
+        vol.Optional(
+            CONF_BATTERY_CHARGE_PRICE_THRESHOLD,
+            description={"suggested_value": d.get(CONF_BATTERY_CHARGE_PRICE_THRESHOLD)},
+        )
+    ] = NumberSelector(
         NumberSelectorConfig(
-            min=0, max=1000, step=0.01,
+            min=0,
+            max=1000,
+            step=0.01,
             mode=NumberSelectorMode.BOX,
         )
     )
 
-    schema_dict[vol.Optional(
-        CONF_FEED_IN_TARIFF,
-        default=d.get(CONF_FEED_IN_TARIFF, 0.0),
-    )] = NumberSelector(
+    schema_dict[
+        vol.Optional(
+            CONF_FEED_IN_TARIFF,
+            default=d.get(CONF_FEED_IN_TARIFF, 0.0),
+        )
+    ] = NumberSelector(
         NumberSelectorConfig(
-            min=0, max=1000, step=0.001,
+            min=0,
+            max=1000,
+            step=0.001,
             mode=NumberSelectorMode.BOX,
         )
     )
 
-    schema_dict[vol.Optional(
-        CONF_FEED_IN_TARIFF_SENSOR,
-        description={"suggested_value": d.get(CONF_FEED_IN_TARIFF_SENSOR)},
-    )] = EntitySelector(
-        EntitySelectorConfig(domain=["sensor", "input_number"])
-    )
+    schema_dict[
+        vol.Optional(
+            CONF_FEED_IN_TARIFF_SENSOR,
+            description={"suggested_value": d.get(CONF_FEED_IN_TARIFF_SENSOR)},
+        )
+    ] = EntitySelector(EntitySelectorConfig(domain=["sensor", "input_number"]))
 
     return vol.Schema(schema_dict)
 
@@ -656,8 +711,18 @@ def _forecast_schema(
     }
 
     if forecast_provider != ForecastProvider.NONE:
-        schema_dict[vol.Required(CONF_FORECAST_SENSOR, description={"suggested_value": d.get(CONF_FORECAST_SENSOR)})] = SENSOR_ENTITY_SELECTOR
-        schema_dict[vol.Optional(CONF_FORECAST_TOMORROW_SENSOR, description={"suggested_value": d.get(CONF_FORECAST_TOMORROW_SENSOR)})] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Required(
+                CONF_FORECAST_SENSOR,
+                description={"suggested_value": d.get(CONF_FORECAST_SENSOR)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
+        schema_dict[
+            vol.Optional(
+                CONF_FORECAST_TOMORROW_SENSOR,
+                description={"suggested_value": d.get(CONF_FORECAST_TOMORROW_SENSOR)},
+            )
+        ] = SENSOR_ENTITY_SELECTOR
 
     return vol.Schema(schema_dict)
 
@@ -681,7 +746,10 @@ def _battery_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 default=d.get(CONF_BATTERY_TARGET_SOC, 80),
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=0, max=100, step=1, unit_of_measurement="%",
+                    min=0,
+                    max=100,
+                    step=1,
+                    unit_of_measurement="%",
                     mode=NumberSelectorMode.SLIDER,
                 )
             ),
@@ -695,14 +763,21 @@ def _battery_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
             ): BooleanSelector(),
             vol.Optional(
                 CONF_BATTERY_MAX_DISCHARGE_ENTITY,
-                description={"suggested_value": d.get(CONF_BATTERY_MAX_DISCHARGE_ENTITY)},
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_MAX_DISCHARGE_ENTITY)
+                },
             ): NUMBER_ENTITY_SELECTOR,
             vol.Optional(
                 CONF_BATTERY_MAX_DISCHARGE_DEFAULT,
-                description={"suggested_value": d.get(CONF_BATTERY_MAX_DISCHARGE_DEFAULT)},
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_MAX_DISCHARGE_DEFAULT)
+                },
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=0, max=100000, step=1, unit_of_measurement="W",
+                    min=0,
+                    max=100000,
+                    step=1,
+                    unit_of_measurement="W",
                     mode=NumberSelectorMode.BOX,
                 )
             ),
@@ -711,7 +786,10 @@ def _battery_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 description={"suggested_value": d.get(CONF_MIN_BATTERY_SOC)},
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=0, max=100, step=1, unit_of_measurement="%",
+                    min=0,
+                    max=100,
+                    step=1,
+                    unit_of_measurement="%",
                     mode=NumberSelectorMode.SLIDER,
                 )
             ),
@@ -721,52 +799,95 @@ def _battery_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
             ): BooleanSelector(),
             vol.Optional(
                 CONF_BATTERY_GRID_CHARGE_POWER_W,
-                description={"suggested_value": d.get(CONF_BATTERY_GRID_CHARGE_POWER_W)},
-            ): NumberSelector(NumberSelectorConfig(
-                min=0, max=20000, step=10, unit_of_measurement="W",
-                mode=NumberSelectorMode.BOX,
-            )),
+                description={
+                    "suggested_value": d.get(CONF_BATTERY_GRID_CHARGE_POWER_W)
+                },
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=0,
+                    max=20000,
+                    step=10,
+                    unit_of_measurement="W",
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
             vol.Required(
                 CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
-                default=d.get(CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES, DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES),
-            ): NumberSelector(NumberSelectorConfig(
-                min=1, max=60, step=1, unit_of_measurement="min",
-                mode=NumberSelectorMode.BOX,
-            )),
+                default=d.get(
+                    CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
+                    DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
+                ),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=60,
+                    step=1,
+                    unit_of_measurement="min",
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY)},
-            ): EntitySelector(EntitySelectorConfig(
-                domain=["input_select", "select", "switch", "input_boolean"],
-            )),
+                description={
+                    "suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY)
+                },
+            ): EntitySelector(
+                EntitySelectorConfig(
+                    domain=["input_select", "select", "switch", "input_boolean"],
+                )
+            ),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE)},
+                description={
+                    "suggested_value": d.get(
+                        CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE
+                    )
+                },
             ): TextSelector(),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE)},
+                description={
+                    "suggested_value": d.get(
+                        CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE
+                    )
+                },
             ): TextSelector(),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY)},
-            ): EntitySelector(EntitySelectorConfig(
-                domain=["input_select", "select", "switch", "input_boolean"],
-            )),
+                description={
+                    "suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY)
+                },
+            ): EntitySelector(
+                EntitySelectorConfig(
+                    domain=["input_select", "select", "switch", "input_boolean"],
+                )
+            ),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE)},
+                description={
+                    "suggested_value": d.get(
+                        CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE
+                    )
+                },
             ): TextSelector(),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE)},
+                description={
+                    "suggested_value": d.get(
+                        CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE
+                    )
+                },
             ): TextSelector(),
             vol.Optional(
                 CONF_INVERTER_FORCE_CHARGE_POWER_ENTITY,
-                description={"suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_POWER_ENTITY)},
-            ): EntitySelector(EntitySelectorConfig(
-                domain=["input_number", "number"],
-            )),
+                description={
+                    "suggested_value": d.get(CONF_INVERTER_FORCE_CHARGE_POWER_ENTITY)
+                },
+            ): EntitySelector(
+                EntitySelectorConfig(
+                    domain=["input_number", "number"],
+                )
+            ),
         }
     )
 
@@ -824,7 +945,22 @@ def _settings_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 default=d.get(CONF_EXPORT_LIMIT, 0),
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=0, max=100000, step=1, unit_of_measurement="W",
+                    min=0,
+                    max=100000,
+                    step=1,
+                    unit_of_measurement="W",
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(
+                CONF_ON_THRESHOLD,
+                default=d.get(CONF_ON_THRESHOLD, DEFAULT_ON_THRESHOLD),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=000,
+                    max=500,
+                    step=10,
+                    unit_of_measurement="W",
                     mode=NumberSelectorMode.BOX,
                 )
             ),
@@ -833,13 +969,18 @@ def _settings_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 default=d.get(CONF_OFF_THRESHOLD, DEFAULT_OFF_THRESHOLD),
             ): NumberSelector(
                 NumberSelectorConfig(
-                    min=-500, max=0, step=10, unit_of_measurement="W",
+                    min=-500,
+                    max=0,
+                    step=10,
+                    unit_of_measurement="W",
                     mode=NumberSelectorMode.BOX,
                 )
             ),
             vol.Required(
                 CONF_CONTROLLER_INTERVAL,
-                default=str(d.get(CONF_CONTROLLER_INTERVAL, DEFAULT_CONTROLLER_INTERVAL)),
+                default=str(
+                    d.get(CONF_CONTROLLER_INTERVAL, DEFAULT_CONTROLLER_INTERVAL)
+                ),
             ): SelectSelector(
                 SelectSelectorConfig(
                     options=CONTROLLER_INTERVAL_OPTIONS,
@@ -871,9 +1012,7 @@ def _settings_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
             vol.Optional(
                 CONF_NOTIFICATION_SERVICE,
                 description={"suggested_value": d.get(CONF_NOTIFICATION_SERVICE)},
-            ): TextSelector(
-                TextSelectorConfig(type=TextSelectorType.TEXT)
-            ),
+            ): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
             vol.Required(
                 CONF_NOTIFY_APPLIANCE_ON,
                 default=d.get(CONF_NOTIFY_APPLIANCE_ON, True),
@@ -939,7 +1078,10 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_GRID_VOLTAGE, default=DEFAULT_GRID_VOLTAGE
                 ): NumberSelector(
                     NumberSelectorConfig(
-                        min=100, max=500, step=1, unit_of_measurement="V",
+                        min=100,
+                        max=500,
+                        step=1,
+                        unit_of_measurement="V",
                         mode=NumberSelectorMode.BOX,
                     )
                 ),
@@ -977,8 +1119,14 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 self.data.update(user_input)
                 # Clean optional sensor keys not present in user_input
-                for key in [CONF_GRID_EXPORT, CONF_IMPORT_EXPORT, CONF_LOAD_POWER,
-                            CONF_BATTERY_POWER, CONF_BATTERY_CHARGE_POWER, CONF_BATTERY_DISCHARGE_POWER]:
+                for key in [
+                    CONF_GRID_EXPORT,
+                    CONF_IMPORT_EXPORT,
+                    CONF_LOAD_POWER,
+                    CONF_BATTERY_POWER,
+                    CONF_BATTERY_CHARGE_POWER,
+                    CONF_BATTERY_DISCHARGE_POWER,
+                ]:
                     if key not in user_input:
                         self.data.pop(key, None)
                 return await self.async_step_energy()
@@ -1007,9 +1155,7 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             tariff = user_input.get(CONF_TARIFF_PROVIDER, TariffProvider.NONE)
 
             # Any non-None provider requires a price sensor entity
-            if tariff != TariffProvider.NONE and not user_input.get(
-                CONF_PRICE_SENSOR
-            ):
+            if tariff != TariffProvider.NONE and not user_input.get(CONF_PRICE_SENSOR):
                 errors[CONF_PRICE_SENSOR] = "missing_price_sensor"
 
             if not errors:
@@ -1048,9 +1194,7 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            provider = user_input.get(
-                CONF_FORECAST_PROVIDER, ForecastProvider.NONE
-            )
+            provider = user_input.get(CONF_FORECAST_PROVIDER, ForecastProvider.NONE)
             # Any non-None provider requires a forecast sensor entity
             if provider != ForecastProvider.NONE and not user_input.get(
                 CONF_FORECAST_SENSOR
@@ -1060,9 +1204,7 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not errors:
                 self.data.update(user_input)
                 # If hybrid, go to battery step; otherwise skip to settings
-                is_hybrid = (
-                    self.data.get(CONF_INVERTER_TYPE) == InverterType.HYBRID
-                )
+                is_hybrid = self.data.get(CONF_INVERTER_TYPE) == InverterType.HYBRID
                 if is_hybrid:
                     return await self.async_step_battery()
                 return await self.async_step_settings()
@@ -1126,27 +1268,24 @@ class PvExcessControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the global settings step and create the config entry."""
         errors: dict[str, str] = {}
 
-        if user_input is not None:
-            if not errors:
-                # Convert string interval values to integers
-                controller_interval = int(
-                    user_input.get(
-                        CONF_CONTROLLER_INTERVAL, str(DEFAULT_CONTROLLER_INTERVAL)
-                    )
+        if user_input is not None and not errors:
+            # Convert string interval values to integers
+            controller_interval = int(
+                user_input.get(
+                    CONF_CONTROLLER_INTERVAL, str(DEFAULT_CONTROLLER_INTERVAL)
                 )
-                planner_interval = int(
-                    user_input.get(
-                        CONF_PLANNER_INTERVAL, str(DEFAULT_PLANNER_INTERVAL)
-                    )
-                )
-                user_input[CONF_CONTROLLER_INTERVAL] = controller_interval
-                user_input[CONF_PLANNER_INTERVAL] = planner_interval
+            )
+            planner_interval = int(
+                user_input.get(CONF_PLANNER_INTERVAL, str(DEFAULT_PLANNER_INTERVAL))
+            )
+            user_input[CONF_CONTROLLER_INTERVAL] = controller_interval
+            user_input[CONF_PLANNER_INTERVAL] = planner_interval
 
-                self.data.update(user_input)
-                return self.async_create_entry(
-                    title="PV Excess Control",
-                    data=self.data,
-                )
+            self.data.update(user_input)
+            return self.async_create_entry(
+                title="PV Excess Control",
+                data=self.data,
+            )
 
         return self.async_show_form(
             step_id="settings",
@@ -1219,7 +1358,10 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
                     default=form_defaults.get(CONF_GRID_VOLTAGE, DEFAULT_GRID_VOLTAGE),
                 ): NumberSelector(
                     NumberSelectorConfig(
-                        min=100, max=500, step=1, unit_of_measurement="V",
+                        min=100,
+                        max=500,
+                        step=1,
+                        unit_of_measurement="V",
                         mode=NumberSelectorMode.BOX,
                     )
                 ),
@@ -1248,8 +1390,14 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
             if not errors:
                 self.data.update(user_input)
                 # Clean optional sensor keys not present in user_input
-                for key in [CONF_GRID_EXPORT, CONF_IMPORT_EXPORT, CONF_LOAD_POWER,
-                            CONF_BATTERY_POWER, CONF_BATTERY_CHARGE_POWER, CONF_BATTERY_DISCHARGE_POWER]:
+                for key in [
+                    CONF_GRID_EXPORT,
+                    CONF_IMPORT_EXPORT,
+                    CONF_LOAD_POWER,
+                    CONF_BATTERY_POWER,
+                    CONF_BATTERY_CHARGE_POWER,
+                    CONF_BATTERY_DISCHARGE_POWER,
+                ]:
                     if key not in user_input:
                         self.data.pop(key, None)
                 return await self.async_step_energy()
@@ -1273,9 +1421,7 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
         if user_input is not None:
             tariff = user_input.get(CONF_TARIFF_PROVIDER, TariffProvider.NONE)
             # Any non-None provider requires a price sensor entity
-            if tariff != TariffProvider.NONE and not user_input.get(
-                CONF_PRICE_SENSOR
-            ):
+            if tariff != TariffProvider.NONE and not user_input.get(CONF_PRICE_SENSOR):
                 errors[CONF_PRICE_SENSOR] = "missing_price_sensor"
             if not errors:
                 self.data.update(user_input)
@@ -1307,9 +1453,7 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            provider = user_input.get(
-                CONF_FORECAST_PROVIDER, ForecastProvider.NONE
-            )
+            provider = user_input.get(CONF_FORECAST_PROVIDER, ForecastProvider.NONE)
             # Any non-None provider requires a forecast sensor entity
             if provider != ForecastProvider.NONE and not user_input.get(
                 CONF_FORECAST_SENSOR
@@ -1317,9 +1461,7 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
                 errors[CONF_FORECAST_SENSOR] = "missing_forecast_sensor"
             if not errors:
                 self.data.update(user_input)
-                is_hybrid = (
-                    self.data.get(CONF_INVERTER_TYPE) == InverterType.HYBRID
-                )
+                is_hybrid = self.data.get(CONF_INVERTER_TYPE) == InverterType.HYBRID
                 if is_hybrid:
                     return await self.async_step_battery()
                 return await self.async_step_settings()
@@ -1359,7 +1501,11 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
             if not errors:
                 self.data.update(user_input)
                 # Clean optional battery fields not present in user_input
-                for key in [CONF_MIN_BATTERY_SOC, CONF_BATTERY_MAX_DISCHARGE_ENTITY, CONF_BATTERY_MAX_DISCHARGE_DEFAULT]:
+                for key in [
+                    CONF_MIN_BATTERY_SOC,
+                    CONF_BATTERY_MAX_DISCHARGE_ENTITY,
+                    CONF_BATTERY_MAX_DISCHARGE_DEFAULT,
+                ]:
                     if key not in user_input:
                         self.data.pop(key, None)
                 return await self.async_step_settings()
@@ -1384,9 +1530,7 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
                 )
             )
             planner_interval = int(
-                user_input.get(
-                    CONF_PLANNER_INTERVAL, str(DEFAULT_PLANNER_INTERVAL)
-                )
+                user_input.get(CONF_PLANNER_INTERVAL, str(DEFAULT_PLANNER_INTERVAL))
             )
             user_input[CONF_CONTROLLER_INTERVAL] = controller_interval
             user_input[CONF_PLANNER_INTERVAL] = planner_interval
@@ -1408,10 +1552,14 @@ class PvExcessControlOptionsFlow(config_entries.OptionsFlow):
             # battery-related keys that are no longer applicable.
             if self.data.get(CONF_INVERTER_TYPE) != InverterType.HYBRID:
                 for key in [
-                    CONF_BATTERY_SOC, CONF_BATTERY_POWER,
-                    CONF_BATTERY_CHARGE_POWER, CONF_BATTERY_DISCHARGE_POWER,
-                    CONF_BATTERY_CAPACITY, CONF_BATTERY_STRATEGY,
-                    CONF_BATTERY_TARGET_SOC, CONF_BATTERY_TARGET_TIME,
+                    CONF_BATTERY_SOC,
+                    CONF_BATTERY_POWER,
+                    CONF_BATTERY_CHARGE_POWER,
+                    CONF_BATTERY_DISCHARGE_POWER,
+                    CONF_BATTERY_CAPACITY,
+                    CONF_BATTERY_STRATEGY,
+                    CONF_BATTERY_TARGET_SOC,
+                    CONF_BATTERY_TARGET_TIME,
                     CONF_ALLOW_GRID_CHARGING,
                     CONF_BATTERY_MAX_DISCHARGE_ENTITY,
                     CONF_BATTERY_MAX_DISCHARGE_DEFAULT,
@@ -1481,9 +1629,7 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
 
             if not errors:
                 # Convert phases from string to int
-                user_input[CONF_PHASES] = int(
-                    user_input.get(CONF_PHASES, "1")
-                )
+                user_input[CONF_PHASES] = int(user_input.get(CONF_PHASES, "1"))
                 # Convert priority to int
                 user_input[CONF_APPLIANCE_PRIORITY] = int(
                     user_input.get(CONF_APPLIANCE_PRIORITY, 500)
@@ -1523,14 +1669,24 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                 if min_c >= max_c:
                     errors[CONF_MIN_CURRENT] = "invalid_current_range"
 
-            if not dynamic and user_input.get(CONF_CHEAP_GRID_TARGET_CURRENT) is not None:
-                errors[CONF_CHEAP_GRID_TARGET_CURRENT] = "cheap_grid_target_current_requires_dynamic"
+            if (
+                not dynamic
+                and user_input.get(CONF_CHEAP_GRID_TARGET_CURRENT) is not None
+            ):
+                errors[CONF_CHEAP_GRID_TARGET_CURRENT] = (
+                    "cheap_grid_target_current_requires_dynamic"
+                )
 
             if not errors:
                 self._data.update(user_input)
                 # Clean optional current/EV keys not present in user_input
-                for key in [CONF_CURRENT_ENTITY, CONF_EV_SOC_ENTITY, CONF_EV_CONNECTED_ENTITY,
-                            CONF_EV_TARGET_SOC, CONF_CHEAP_GRID_TARGET_CURRENT]:
+                for key in [
+                    CONF_CURRENT_ENTITY,
+                    CONF_EV_SOC_ENTITY,
+                    CONF_EV_CONNECTED_ENTITY,
+                    CONF_EV_TARGET_SOC,
+                    CONF_CHEAP_GRID_TARGET_CURRENT,
+                ]:
                     if key not in user_input:
                         self._data.pop(key, None)
                 return await self.async_step_constraints()
@@ -1565,7 +1721,9 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
             for sid, sub in getattr(entry, "subentries", {}).items():
                 # Exclude self (for reconfigure, use _subentry_id if available)
                 if sid != getattr(self, "_subentry_id", None):
-                    available_appliances[sid] = sub.data.get("appliance_name", f"Appliance {sid[:8]}")
+                    available_appliances[sid] = sub.data.get(
+                        "appliance_name", f"Appliance {sid[:8]}"
+                    )
 
         if user_input is not None:
             # Clean empty requires_appliance to None
@@ -1582,16 +1740,14 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
 
             # Helper-only + requires_appliance is forbidden — chained
             # helpers are out of scope for v1 (see design spec).
-            if user_input.get(CONF_HELPER_ONLY, False) and user_input.get(CONF_REQUIRES_APPLIANCE):
+            if user_input.get(CONF_HELPER_ONLY, False) and user_input.get(
+                CONF_REQUIRES_APPLIANCE
+            ):
                 errors[CONF_HELPER_ONLY] = "helper_only_with_requires"
 
             min_rt = user_input.get(CONF_MIN_DAILY_RUNTIME)
             max_rt = user_input.get(CONF_MAX_DAILY_RUNTIME)
-            if (
-                min_rt is not None
-                and max_rt is not None
-                and min_rt > max_rt
-            ):
+            if min_rt is not None and max_rt is not None and min_rt > max_rt:
                 errors[CONF_MIN_DAILY_RUNTIME] = "invalid_runtime_range"
 
             # Warn if high-power appliance is not marked as big consumer
@@ -1608,11 +1764,19 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
             if not errors:
                 self._data.update(user_input)
                 # Clean optional constraint keys not present in user_input
-                for key in [CONF_MIN_DAILY_RUNTIME, CONF_MAX_DAILY_RUNTIME, CONF_SCHEDULE_DEADLINE,
-                            CONF_START_AFTER, CONF_END_BEFORE,
-                            CONF_MAX_GRID_POWER, CONF_BATTERY_DISCHARGE_OVERRIDE,
-                            CONF_AVERAGING_WINDOW, CONF_REQUIRES_APPLIANCE,
-                            CONF_ON_THRESHOLD, CONF_COMPLETION_POWER_THRESHOLD]:
+                for key in [
+                    CONF_MIN_DAILY_RUNTIME,
+                    CONF_MAX_DAILY_RUNTIME,
+                    CONF_SCHEDULE_DEADLINE,
+                    CONF_START_AFTER,
+                    CONF_END_BEFORE,
+                    CONF_MAX_GRID_POWER,
+                    CONF_BATTERY_DISCHARGE_OVERRIDE,
+                    CONF_AVERAGING_WINDOW,
+                    CONF_REQUIRES_APPLIANCE,
+                    CONF_ON_THRESHOLD,
+                    CONF_COMPLETION_POWER_THRESHOLD,
+                ]:
                     if key not in user_input:
                         self._data.pop(key, None)
                 title = self._data.get(CONF_APPLIANCE_NAME, "Appliance")
@@ -1622,7 +1786,9 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                 )
 
         form_defaults = {**self._data, **(user_input or {})}
-        schema = _appliance_constraints_schema(form_defaults, available_appliances=available_appliances)
+        schema = _appliance_constraints_schema(
+            form_defaults, available_appliances=available_appliances
+        )
 
         return self.async_show_form(
             step_id="constraints",
@@ -1644,7 +1810,9 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
             return self.async_abort(reason="reconfigure_not_supported")
         subentry = self._get_reconfigure_subentry()
         self._data = dict(subentry.data)
-        self._subentry_id = getattr(subentry, "subentry_id", None) or getattr(subentry, "id", None)
+        self._subentry_id = getattr(subentry, "subentry_id", None) or getattr(
+            subentry, "id", None
+        )
         # Convert phases back to string for the selector
         if CONF_PHASES in self._data:
             self._data[CONF_PHASES] = str(self._data[CONF_PHASES])
@@ -1670,9 +1838,7 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                 errors[CONF_NOMINAL_POWER] = "invalid_power"
 
             if not errors:
-                user_input[CONF_PHASES] = int(
-                    user_input.get(CONF_PHASES, "1")
-                )
+                user_input[CONF_PHASES] = int(user_input.get(CONF_PHASES, "1"))
                 user_input[CONF_APPLIANCE_PRIORITY] = int(
                     user_input.get(CONF_APPLIANCE_PRIORITY, 500)
                 )
@@ -1707,14 +1873,24 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                 if min_c >= max_c:
                     errors[CONF_MIN_CURRENT] = "invalid_current_range"
 
-            if not dynamic and user_input.get(CONF_CHEAP_GRID_TARGET_CURRENT) is not None:
-                errors[CONF_CHEAP_GRID_TARGET_CURRENT] = "cheap_grid_target_current_requires_dynamic"
+            if (
+                not dynamic
+                and user_input.get(CONF_CHEAP_GRID_TARGET_CURRENT) is not None
+            ):
+                errors[CONF_CHEAP_GRID_TARGET_CURRENT] = (
+                    "cheap_grid_target_current_requires_dynamic"
+                )
 
             if not errors:
                 self._data.update(user_input)
                 # Clean optional current/EV keys not present in user_input
-                for key in [CONF_CURRENT_ENTITY, CONF_EV_SOC_ENTITY, CONF_EV_CONNECTED_ENTITY,
-                            CONF_EV_TARGET_SOC, CONF_CHEAP_GRID_TARGET_CURRENT]:
+                for key in [
+                    CONF_CURRENT_ENTITY,
+                    CONF_EV_SOC_ENTITY,
+                    CONF_EV_CONNECTED_ENTITY,
+                    CONF_EV_TARGET_SOC,
+                    CONF_CHEAP_GRID_TARGET_CURRENT,
+                ]:
                     if key not in user_input:
                         self._data.pop(key, None)
                 return await self.async_step_reconfigure_constraints()
@@ -1745,7 +1921,9 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
             for sid, sub in getattr(entry, "subentries", {}).items():
                 # Exclude self (for reconfigure, use _subentry_id if available)
                 if sid != getattr(self, "_subentry_id", None):
-                    available_appliances[sid] = sub.data.get("appliance_name", f"Appliance {sid[:8]}")
+                    available_appliances[sid] = sub.data.get(
+                        "appliance_name", f"Appliance {sid[:8]}"
+                    )
 
         if user_input is not None:
             # Clean empty requires_appliance to None
@@ -1762,16 +1940,14 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
 
             # Helper-only + requires_appliance is forbidden — chained
             # helpers are out of scope for v1 (see design spec).
-            if user_input.get(CONF_HELPER_ONLY, False) and user_input.get(CONF_REQUIRES_APPLIANCE):
+            if user_input.get(CONF_HELPER_ONLY, False) and user_input.get(
+                CONF_REQUIRES_APPLIANCE
+            ):
                 errors[CONF_HELPER_ONLY] = "helper_only_with_requires"
 
             min_rt = user_input.get(CONF_MIN_DAILY_RUNTIME)
             max_rt = user_input.get(CONF_MAX_DAILY_RUNTIME)
-            if (
-                min_rt is not None
-                and max_rt is not None
-                and min_rt > max_rt
-            ):
+            if min_rt is not None and max_rt is not None and min_rt > max_rt:
                 errors[CONF_MIN_DAILY_RUNTIME] = "invalid_runtime_range"
 
             # Warn if high-power appliance is not marked as big consumer
@@ -1788,11 +1964,19 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
             if not errors:
                 self._data.update(user_input)
                 # Clean optional constraint keys not present in user_input
-                for key in [CONF_MIN_DAILY_RUNTIME, CONF_MAX_DAILY_RUNTIME, CONF_SCHEDULE_DEADLINE,
-                            CONF_START_AFTER, CONF_END_BEFORE,
-                            CONF_MAX_GRID_POWER, CONF_BATTERY_DISCHARGE_OVERRIDE,
-                            CONF_AVERAGING_WINDOW, CONF_REQUIRES_APPLIANCE,
-                            CONF_ON_THRESHOLD, CONF_COMPLETION_POWER_THRESHOLD]:
+                for key in [
+                    CONF_MIN_DAILY_RUNTIME,
+                    CONF_MAX_DAILY_RUNTIME,
+                    CONF_SCHEDULE_DEADLINE,
+                    CONF_START_AFTER,
+                    CONF_END_BEFORE,
+                    CONF_MAX_GRID_POWER,
+                    CONF_BATTERY_DISCHARGE_OVERRIDE,
+                    CONF_AVERAGING_WINDOW,
+                    CONF_REQUIRES_APPLIANCE,
+                    CONF_ON_THRESHOLD,
+                    CONF_COMPLETION_POWER_THRESHOLD,
+                ]:
                     if key not in user_input:
                         self._data.pop(key, None)
                 title = self._data.get(CONF_APPLIANCE_NAME, "Appliance")
@@ -1807,14 +1991,26 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                     # Fallback: update subentry via config_entries API
                     try:
                         entry = self.hass.config_entries.async_get_entry(
-                            self.handler[0] if isinstance(self.handler, tuple) else self.handler
+                            self.handler[0]
+                            if isinstance(self.handler, tuple)
+                            else self.handler
                         )
-                        if entry and hasattr(self.hass.config_entries, "async_update_subentry"):
-                            subentry_id = self._subentry_id if hasattr(self, "_subentry_id") else None
-                            if subentry_id and subentry_id in getattr(entry, "subentries", {}):
+                        if entry and hasattr(
+                            self.hass.config_entries, "async_update_subentry"
+                        ):
+                            subentry_id = (
+                                self._subentry_id
+                                if hasattr(self, "_subentry_id")
+                                else None
+                            )
+                            if subentry_id and subentry_id in getattr(
+                                entry, "subentries", {}
+                            ):
                                 self.hass.config_entries.async_update_subentry(
-                                    entry, entry.subentries[subentry_id],
-                                    data=self._data, title=title,
+                                    entry,
+                                    entry.subentries[subentry_id],
+                                    data=self._data,
+                                    title=title,
                                 )
                                 return self.async_abort(reason="reconfigure_successful")
                     except Exception:
@@ -1822,7 +2018,9 @@ class ApplianceSubentryFlowHandler(_SubentryBase):  # type: ignore[misc]
                     return self.async_abort(reason="reconfigure_not_supported")
 
         form_defaults = {**self._data, **(user_input or {})}
-        schema = _appliance_constraints_schema(form_defaults, available_appliances=available_appliances)
+        schema = _appliance_constraints_schema(
+            form_defaults, available_appliances=available_appliances
+        )
 
         return self.async_show_form(
             step_id="reconfigure_constraints",

--- a/custom_components/pv_excess_control/config_flow.py
+++ b/custom_components/pv_excess_control/config_flow.py
@@ -136,6 +136,7 @@ from .const import (
     DEFAULT_PLANNER_INTERVAL,
     DEFAULT_SWITCH_INTERVAL,
     DOMAIN,
+    MAX_AVERAGING_WINDOW,
     MAX_CURRENT,
     MAX_PRIORITY,
     MIN_CURRENT,
@@ -389,7 +390,7 @@ def _appliance_constraints_schema(
         ): NumberSelector(
             NumberSelectorConfig(
                 min=30,
-                max=1800,
+                max=MAX_AVERAGING_WINDOW,
                 step=30,
                 unit_of_measurement="s",
                 mode=NumberSelectorMode.BOX,

--- a/custom_components/pv_excess_control/const.py
+++ b/custom_components/pv_excess_control/const.py
@@ -1,4 +1,5 @@
 """Constants for the PV Excess Control integration."""
+
 from enum import StrEnum
 
 DOMAIN = "pv_excess_control"
@@ -27,12 +28,14 @@ MAX_PHASES = 3
 
 class InverterType(StrEnum):
     """Inverter type."""
+
     STANDARD = "standard"
     HYBRID = "hybrid"
 
 
 class BatteryStrategy(StrEnum):
     """Battery charging strategy."""
+
     BATTERY_FIRST = "battery_first"
     APPLIANCE_FIRST = "appliance_first"
     BALANCED = "balanced"
@@ -40,6 +43,7 @@ class BatteryStrategy(StrEnum):
 
 class PlanInfluence(StrEnum):
     """How much the planner influences optimizer decisions."""
+
     NONE = "none"
     LIGHT = "light"
     PLAN_FOLLOWS = "plan_follows"
@@ -47,6 +51,7 @@ class PlanInfluence(StrEnum):
 
 class Action(StrEnum):
     """Control action for an appliance."""
+
     ON = "on"
     OFF = "off"
     SET_CURRENT = "set_current"
@@ -55,6 +60,7 @@ class Action(StrEnum):
 
 class PlanReason(StrEnum):
     """Reason for a planned action."""
+
     EXCESS_AVAILABLE = "excess_available"
     CHEAP_TARIFF = "cheap_tariff"
     MIN_RUNTIME = "min_runtime"
@@ -70,6 +76,7 @@ class PlanReason(StrEnum):
 
 class TariffProvider(StrEnum):
     """Supported tariff providers."""
+
     NONE = "none"
     GENERIC = "generic"
     TIBBER = "tibber"
@@ -80,6 +87,7 @@ class TariffProvider(StrEnum):
 
 class ForecastProvider(StrEnum):
     """Supported forecast providers."""
+
     NONE = "none"
     SOLCAST = "solcast"
     FORECAST_SOLAR = "forecast_solar"
@@ -88,6 +96,7 @@ class ForecastProvider(StrEnum):
 
 class NotificationEvent(StrEnum):
     """Notification event types."""
+
     APPLIANCE_ON = "appliance_on"
     APPLIANCE_OFF = "appliance_off"
     OVERRIDE_ACTIVATED = "override_activated"
@@ -145,11 +154,17 @@ CONF_BATTERY_GRID_CHARGE_POWER_W = "battery_grid_charge_power_w"
 CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES = "grid_charge_engage_min_duration_minutes"
 
 CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY = "inverter_force_charge_enable_entity"
-CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE = "inverter_force_charge_enable_engage_value"
-CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE = "inverter_force_charge_enable_disengage_value"
+CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE = (
+    "inverter_force_charge_enable_engage_value"
+)
+CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE = (
+    "inverter_force_charge_enable_disengage_value"
+)
 CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY = "inverter_force_charge_mode_entity"
 CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE = "inverter_force_charge_mode_engage_value"
-CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE = "inverter_force_charge_mode_disengage_value"
+CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE = (
+    "inverter_force_charge_mode_disengage_value"
+)
 CONF_INVERTER_FORCE_CHARGE_POWER_ENTITY = "inverter_force_charge_power_entity"
 
 DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES = 5

--- a/custom_components/pv_excess_control/const.py
+++ b/custom_components/pv_excess_control/const.py
@@ -24,6 +24,7 @@ MIN_CURRENT = 0.0
 MAX_CURRENT = 32.0
 MIN_PHASES = 1
 MAX_PHASES = 3
+MAX_AVERAGING_WINDOW = 1800  # seconds
 
 
 class InverterType(StrEnum):

--- a/custom_components/pv_excess_control/controller.py
+++ b/custom_components/pv_excess_control/controller.py
@@ -6,6 +6,7 @@ Bridges Home Assistant state with the optimizer:
 - Applies ControlDecisions by calling HA services
 - Handles safety checks (switch interval, on_only)
 """
+
 from __future__ import annotations
 
 import logging
@@ -58,14 +59,20 @@ class Controller:
     def __init__(self, hass: HomeAssistant, config_data: dict) -> None:
         self.hass = hass
         self.config_data = config_data
-        self._last_state_change: dict[str, datetime] = {}  # appliance_id -> last change time
+        self._last_state_change: dict[
+            str, datetime
+        ] = {}  # appliance_id -> last change time
 
     # ------------------------------------------------------------------
     # Sensor reading helpers
     # ------------------------------------------------------------------
 
     def _read_sensor(
-        self, entity_id: str | None, default: float = 0.0, *, power: bool = False,
+        self,
+        entity_id: str | None,
+        default: float = 0.0,
+        *,
+        power: bool = False,
     ) -> float:
         """Read a numeric sensor value, returning default if unavailable.
 
@@ -86,7 +93,10 @@ class Controller:
         return val
 
     def _read_sensor_optional(
-        self, entity_id: str | None, *, power: bool = False,
+        self,
+        entity_id: str | None,
+        *,
+        power: bool = False,
     ) -> float | None:
         """Read a numeric sensor value, returning None if unavailable.
 
@@ -143,7 +153,8 @@ class Controller:
 
         battery_soc = self._read_sensor_optional(data.get(CONF_BATTERY_SOC))
         battery_power = self._read_sensor_optional(
-            data.get(CONF_BATTERY_POWER), power=True,
+            data.get(CONF_BATTERY_POWER),
+            power=True,
         )
 
         # Calculate excess: PV production minus load; if no load sensor, use grid export
@@ -180,13 +191,17 @@ class Controller:
             entity_state = self.hass.states.get(config.entity_id)
             is_on = False
             if entity_state is not None:
-                is_on = entity_state.state not in _OFF_STATES and entity_state.state not in _UNAVAILABLE_STATES
+                is_on = (
+                    entity_state.state not in _OFF_STATES
+                    and entity_state.state not in _UNAVAILABLE_STATES
+                )
 
             # Read actual power if available
             current_power = 0.0
             if config.actual_power_entity:
                 current_power = self._read_sensor(
-                    config.actual_power_entity, power=True,
+                    config.actual_power_entity,
+                    power=True,
                 )
 
             # Read current amperage if available
@@ -243,18 +258,29 @@ class Controller:
                 remaining = max(config.switch_interval - elapsed, 0)
                 _LOGGER.debug(
                     "Skip %s: switch interval (%ds remaining)",
-                    config.name, int(remaining),
+                    config.name,
+                    int(remaining),
                 )
                 continue
 
             # Check if state actually needs to change
             current_state = self.hass.states.get(config.entity_id)
             if not self._needs_change(decision, current_state, config):
-                entity_state = getattr(current_state, "state", None) if current_state else None
-                is_on = (entity_state not in _OFF_STATES and entity_state not in _UNAVAILABLE_STATES) if entity_state else False
+                entity_state = (
+                    getattr(current_state, "state", None) if current_state else None
+                )
+                is_on = (
+                    (
+                        entity_state not in _OFF_STATES
+                        and entity_state not in _UNAVAILABLE_STATES
+                    )
+                    if entity_state
+                    else False
+                )
                 _LOGGER.debug(
                     "Skip %s: already %s",
-                    config.name, "on" if is_on else "off",
+                    config.name,
+                    "on" if is_on else "off",
                 )
                 continue
 
@@ -264,9 +290,9 @@ class Controller:
             _LOGGER.info(
                 "Calling %s.%s for %s (%s)",
                 domain,
-                "turn_on" if decision.action == Action.ON else (
-                    "turn_off" if decision.action == Action.OFF else "set_value"
-                ),
+                "turn_on"
+                if decision.action == Action.ON
+                else ("turn_off" if decision.action == Action.OFF else "set_value"),
                 config.name,
                 entity_id,
             )
@@ -300,7 +326,8 @@ class Controller:
         if action.should_limit and action.max_discharge_watts is not None:
             _LOGGER.debug(
                 "Battery discharge limit: %s -> %.0fW",
-                max_discharge_entity, action.max_discharge_watts,
+                max_discharge_entity,
+                action.max_discharge_watts,
             )
             await self.hass.services.async_call(
                 "number",
@@ -313,7 +340,8 @@ class Controller:
         elif max_discharge_default is not None:
             _LOGGER.debug(
                 "Battery discharge limit: %s -> %.0fW (restoring default)",
-                max_discharge_entity, max_discharge_default,
+                max_discharge_entity,
+                max_discharge_default,
             )
             await self.hass.services.async_call(
                 "number",
@@ -360,7 +388,10 @@ class Controller:
 
         if decision.action == Action.ON:
             # Already on - no change needed
-            if entity_state not in _OFF_STATES and entity_state not in _UNAVAILABLE_STATES:
+            if (
+                entity_state not in _OFF_STATES
+                and entity_state not in _UNAVAILABLE_STATES
+            ):
                 return False
         elif decision.action == Action.OFF:
             # Already off - no change needed
@@ -389,17 +420,20 @@ class Controller:
             if config.on_only:
                 return
             await self._turn_off(domain, entity_id)
-        elif decision.action == Action.SET_CURRENT:
-            if config.current_entity and decision.target_current is not None:
-                current_domain = config.current_entity.split(".")[0]
-                await self.hass.services.async_call(
-                    current_domain,
-                    "set_value",
-                    {
-                        "entity_id": config.current_entity,
-                        "value": decision.target_current,
-                    },
-                )
+        elif (
+            decision.action == Action.SET_CURRENT
+            and config.current_entity
+            and decision.target_current is not None
+        ):
+            current_domain = config.current_entity.split(".")[0]
+            await self.hass.services.async_call(
+                current_domain,
+                "set_value",
+                {
+                    "entity_id": config.current_entity,
+                    "value": decision.target_current,
+                },
+            )
 
     async def _turn_on(self, domain: str, entity_id: str) -> None:
         """Turn on an entity based on its domain."""

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -1273,9 +1273,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 current_step=sub_data.get(CONF_CURRENT_STEP, 0.1),
                 override_active=override_active,
                 max_daily_activations=max_activations,
-                on_threshold=sub_data.get(
-                    CONF_ON_THRESHOLD,
-                    global_on_threshold,
+                on_threshold=(
+                    sub_data.get(CONF_ON_THRESHOLD)
+                    if sub_data.get(CONF_DYNAMIC_CURRENT, False)
+                    else sub_data.get(CONF_ON_THRESHOLD, global_on_threshold)
                 ),
                 completion_power_threshold=sub_data.get(
                     CONF_COMPLETION_POWER_THRESHOLD

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -104,6 +104,7 @@ from .const import (
     DEFAULT_STARTUP_GRACE_PERIOD,
     DEFAULT_SWITCH_INTERVAL,
     DOMAIN,
+    MAX_AVERAGING_WINDOW,
     BatteryStrategy,
     PlanInfluence,
     TariffProvider as TariffProviderEnum,
@@ -147,10 +148,17 @@ _LOGGER = logging.getLogger(__name__)
 _OFF_STATES = {"off", "false", "False", "0"}
 _UNAVAILABLE_STATES = {STATE_UNAVAILABLE, STATE_UNKNOWN, "none", ""}
 
-# Maximum number of power history entries to keep (~30 min at 30s intervals)
-MAX_HISTORY_SIZE = 60
 _DAILY_STATE_STORAGE_VERSION = 1
 _DAILY_STATE_SAVE_DELAY = 60
+
+
+def _history_size_for_interval(controller_interval: int) -> int:
+    """Return the number of samples needed for the maximum averaging window."""
+    return max(
+        1,
+        math.ceil(MAX_AVERAGING_WINDOW / max(controller_interval, 1)),
+    )
+
 
 # Multipliers to normalise power values to watts.
 _POWER_UNIT_MULTIPLIERS: dict[str, float] = {
@@ -247,6 +255,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=config_entry,
             update_interval=timedelta(seconds=controller_interval),
         )
+        self._max_history_size = _history_size_for_interval(controller_interval)
 
         grid_voltage = config_entry.data.get(CONF_GRID_VOLTAGE, DEFAULT_GRID_VOLTAGE)
         tz_name = (
@@ -259,6 +268,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             timezone_str=tz_name,
             enable_preemption=enable_preemption,
             off_threshold=off_threshold,
+            controller_interval=controller_interval,
         )
         self.planner = Planner(grid_voltage=grid_voltage, timezone_str=tz_name)
 
@@ -733,10 +743,11 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _fmt(power_state.excess_power),
         )
 
-        # 2. Append to history (keep last MAX_HISTORY_SIZE entries)
+        # 2. Append to history. Keep enough samples to cover the maximum
+        # configurable averaging window regardless of controller interval.
         self.power_history.append(power_state)
-        if len(self.power_history) > MAX_HISTORY_SIZE:
-            self.power_history.pop(0)
+        if len(self.power_history) > self._max_history_size:
+            del self.power_history[: -self._max_history_size]
 
         # 3. Run planner on its interval
         self._planner_counter += 1

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -1182,6 +1182,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _get_appliance_configs(self) -> list[ApplianceConfig]:
         """Convert config entry subentries to ApplianceConfig list."""
         configs: list[ApplianceConfig] = []
+        global_on_threshold = self.config_entry.data.get(CONF_ON_THRESHOLD)
 
         # Subentries are stored in config_entry.subentries (HA 2024.12+)
         subentries = getattr(self.config_entry, "subentries", {})
@@ -1272,7 +1273,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 current_step=sub_data.get(CONF_CURRENT_STEP, 0.1),
                 override_active=override_active,
                 max_daily_activations=max_activations,
-                on_threshold=sub_data.get(CONF_ON_THRESHOLD),
+                on_threshold=sub_data.get(
+                    CONF_ON_THRESHOLD,
+                    global_on_threshold,
+                ),
                 completion_power_threshold=sub_data.get(
                     CONF_COMPLETION_POWER_THRESHOLD
                 ),

--- a/custom_components/pv_excess_control/coordinator.py
+++ b/custom_components/pv_excess_control/coordinator.py
@@ -7,6 +7,7 @@ Central data hub that:
 4. Runs the planner on a slower cadence
 5. Applies control decisions to HA entities
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -19,7 +20,9 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_ALLOW_GRID_CHARGING,
@@ -146,6 +149,8 @@ _UNAVAILABLE_STATES = {STATE_UNAVAILABLE, STATE_UNKNOWN, "none", ""}
 
 # Maximum number of power history entries to keep (~30 min at 30s intervals)
 MAX_HISTORY_SIZE = 60
+_DAILY_STATE_STORAGE_VERSION = 1
+_DAILY_STATE_SAVE_DELAY = 60
 
 # Multipliers to normalise power values to watts.
 _POWER_UNIT_MULTIPLIERS: dict[str, float] = {
@@ -244,7 +249,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         grid_voltage = config_entry.data.get(CONF_GRID_VOLTAGE, DEFAULT_GRID_VOLTAGE)
-        tz_name = str(hass.config.time_zone) if hasattr(hass.config, 'time_zone') else "UTC"
+        tz_name = (
+            str(hass.config.time_zone) if hasattr(hass.config, "time_zone") else "UTC"
+        )
         enable_preemption = config_entry.data.get(CONF_ENABLE_PREEMPTION, True)
         off_threshold = config_entry.data.get(CONF_OFF_THRESHOLD, DEFAULT_OFF_THRESHOLD)
         self.optimizer = Optimizer(
@@ -270,6 +277,12 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_appliance_configs: list[ApplianceConfig] = []
         self.current_plan: Plan | None = None
         self.appliance_states: dict[str, ApplianceState] = {}
+        self._restored_daily_state: dict[str, dict[str, float | int]] = {}
+        self._daily_state_store: Store[dict[str, Any]] = Store(
+            hass,
+            _DAILY_STATE_STORAGE_VERSION,
+            f"{DOMAIN}.{config_entry.entry_id}.daily_state",
+        )
         self.control_decisions: list[ControlDecision] = []
         self.battery_discharge_action: BatteryDischargeAction | None = None
 
@@ -298,8 +311,12 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.force_charge: bool = config_entry.data.get("force_charge", False)
 
         # Inverter forced grid-charge state machine
-        self._inverter_ctl: InverterGridChargeController | None = self._build_inverter_controller()
-        self._grid_charge_engaged: bool = config_entry.data.get("_grid_charge_engaged", False)
+        self._inverter_ctl: InverterGridChargeController | None = (
+            self._build_inverter_controller()
+        )
+        self._grid_charge_engaged: bool = config_entry.data.get(
+            "_grid_charge_engaged", False
+        )
         self._grid_charge_engage_ts: float | None = None
         self._force_charge_prev: bool = self.force_charge
         self._latest_tariff = None
@@ -308,9 +325,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Restore persisted enabled/override state from config_entry.data
         disabled_ids = set(config_entry.data.get("disabled_appliances", []))
         overridden_ids = set(config_entry.data.get("overridden_appliances", []))
-        self.appliance_enabled: dict[str, bool] = {
-            aid: False for aid in disabled_ids
-        }
+        self.appliance_enabled: dict[str, bool] = {aid: False for aid in disabled_ids}
         self.appliance_overrides: dict[str, bool] = {
             aid: True for aid in overridden_ids
         }
@@ -327,9 +342,13 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Seed only when the key exists; absence means "no override" —
             # the read path falls through to subentry.data.
             if CONF_MIN_DAILY_RUNTIME in d:
-                self.appliance_min_daily_runtime[subentry_id] = d[CONF_MIN_DAILY_RUNTIME]
+                self.appliance_min_daily_runtime[subentry_id] = d[
+                    CONF_MIN_DAILY_RUNTIME
+                ]
             if CONF_MAX_DAILY_RUNTIME in d:
-                self.appliance_max_daily_runtime[subentry_id] = d[CONF_MAX_DAILY_RUNTIME]
+                self.appliance_max_daily_runtime[subentry_id] = d[
+                    CONF_MAX_DAILY_RUNTIME
+                ]
 
         # Track last-set battery discharge limit to avoid redundant calls.
         # Seed from actual entity value on startup to avoid unnecessary service calls.
@@ -381,7 +400,8 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             CONF_NOTIFY_DAILY_SUMMARY, True
         )
         self.notifications = NotificationManager(
-            hass, notification_settings=notification_settings,
+            hass,
+            notification_settings=notification_settings,
             notification_service=notification_service,
         )
 
@@ -404,7 +424,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "Tariff provider '%s' configured but no price_sensor entity set",
                 tariff_type,
             )
-        self._tariff_provider = create_tariff_provider(tariff_type, price_entity, timezone_str=tz_name)
+        self._tariff_provider = create_tariff_provider(
+            tariff_type, price_entity, timezone_str=tz_name
+        )
 
         # Forecast provider
         forecast_type = config_entry.data.get(
@@ -416,7 +438,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 forecast_type, forecast_entity
             )
         elif forecast_type != ForecastProviderEnum.NONE and not forecast_entity:
-            _LOGGER.warning("Forecast provider '%s' configured but no forecast_sensor entity set", forecast_type)
+            _LOGGER.warning(
+                "Forecast provider '%s' configured but no forecast_sensor entity set",
+                forecast_type,
+            )
             self._forecast_provider = None
         else:
             self._forecast_provider = None
@@ -432,6 +457,75 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._planner_interval,
         )
 
+    async def async_restore_daily_state(self) -> None:
+        """Restore today's runtime, energy and activation counters."""
+        data = await self._daily_state_store.async_load()
+        if not data or data.get("date") != dt_util.now().date().isoformat():
+            return
+
+        appliances = data.get("appliances")
+        if not isinstance(appliances, dict):
+            return
+
+        restored: dict[str, dict[str, float | int]] = {}
+        activations: dict[str, int] = {}
+        for appliance_id, values in appliances.items():
+            if not isinstance(values, dict):
+                continue
+            try:
+                runtime_seconds = max(0.0, float(values.get("runtime_seconds", 0.0)))
+                energy_kwh = max(0.0, float(values.get("energy_kwh", 0.0)))
+                activation_count = max(0, int(values.get("activations", 0)))
+            except (TypeError, ValueError):
+                continue
+            restored[appliance_id] = {
+                "runtime_seconds": runtime_seconds,
+                "energy_kwh": energy_kwh,
+                "activations": activation_count,
+            }
+            activations[appliance_id] = activation_count
+
+        self._restored_daily_state = restored
+        self._activations_today = activations
+        _LOGGER.debug("Restored daily counters for %d appliances", len(restored))
+
+    def _daily_state_data(self) -> dict[str, Any]:
+        """Build serialisable storage data for today's per-appliance counters."""
+        appliances: dict[str, dict[str, float | int]] = {}
+        all_ids = set(self.appliance_states) | set(self._activations_today)
+        for appliance_id in all_ids:
+            state = self.appliance_states.get(appliance_id)
+            restored = self._restored_daily_state.get(appliance_id, {})
+            appliances[appliance_id] = {
+                "runtime_seconds": (
+                    state.runtime_today.total_seconds()
+                    if state is not None
+                    else float(restored.get("runtime_seconds", 0.0))
+                ),
+                "energy_kwh": (
+                    state.energy_today
+                    if state is not None
+                    else float(restored.get("energy_kwh", 0.0))
+                ),
+                "activations": self._activations_today.get(
+                    appliance_id, int(restored.get("activations", 0))
+                ),
+            }
+        return {
+            "date": dt_util.now().date().isoformat(),
+            "appliances": appliances,
+        }
+
+    def _schedule_daily_state_save(self) -> None:
+        """Persist counters with a short debounce to avoid excessive disk writes."""
+        self._daily_state_store.async_delay_save(
+            self._daily_state_data, _DAILY_STATE_SAVE_DELAY
+        )
+
+    async def async_save_daily_state(self) -> None:
+        """Immediately persist the current daily counters."""
+        await self._daily_state_store.async_save(self._daily_state_data())
+
     # ------------------------------------------------------------------
     # Inverter grid-charge helpers (Task 10 plumbing)
     # ------------------------------------------------------------------
@@ -444,8 +538,12 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return None
         cfg = InverterGridChargeConfig(
             enable_entity_id=enable_entity,
-            enable_engage_value=d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE, ""),
-            enable_disengage_value=d.get(CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE, ""),
+            enable_engage_value=d.get(
+                CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE, ""
+            ),
+            enable_disengage_value=d.get(
+                CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE, ""
+            ),
             mode_entity_id=d.get(CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY),
             mode_engage_value=d.get(CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE),
             mode_disengage_value=d.get(CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE),
@@ -474,13 +572,18 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._latest_tariff is None or self._latest_power_state is None:
             return False
         target_soc = d.get(CONF_BATTERY_TARGET_SOC, 80)
-        cheap_now = self._latest_tariff.current_price <= self._latest_tariff.battery_charge_price_threshold
+        cheap_now = (
+            self._latest_tariff.current_price
+            <= self._latest_tariff.battery_charge_price_threshold
+        )
         soc = self._latest_power_state.battery_soc
         soc_below_target = soc is None or soc < target_soc
         return cheap_now and soc_below_target
 
     async def _run_grid_charge_state_machine(
-        self, tariff_info, power_state,
+        self,
+        tariff_info,
+        power_state,
     ) -> None:
         """Engage / disengage forced grid charge based on price + SoC + force_charge.
 
@@ -493,16 +596,23 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         auto_flag = d.get(CONF_AUTO_BATTERY_GRID_CHARGE, False)
         target_soc = d.get(CONF_BATTERY_TARGET_SOC, 80)
-        min_dur_s = d.get(
-            CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
-            DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
-        ) * 60
+        min_dur_s = (
+            d.get(
+                CONF_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
+                DEFAULT_GRID_CHARGE_ENGAGE_MIN_DURATION_MINUTES,
+            )
+            * 60
+        )
 
         cheap_now = (
             tariff_info is not None
             and tariff_info.current_price <= tariff_info.battery_charge_price_threshold
         )
-        soc = getattr(power_state, "battery_soc", None) if power_state is not None else None
+        soc = (
+            getattr(power_state, "battery_soc", None)
+            if power_state is not None
+            else None
+        )
         soc_below_target = soc is None or soc < target_soc
 
         auto_should_engage = auto_flag and cheap_now and soc_below_target
@@ -516,7 +626,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._grid_charge_engaged = True
             self._grid_charge_engage_ts = _time.monotonic()
             self._persist_grid_charge_state(True)
-            method = getattr(self.notifications, "notify_battery_grid_charge_engaged", None)
+            method = getattr(
+                self.notifications, "notify_battery_grid_charge_engaged", None
+            )
             if method is not None:
                 try:
                     await method(power_w)
@@ -531,15 +643,20 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._grid_charge_engage_ts = None
                 self._persist_grid_charge_state(False)
                 reason = (
-                    "manual force_charge switch off" if force_off_edge
+                    "manual force_charge switch off"
+                    if force_off_edge
                     else "price above threshold or SoC reached target"
                 )
-                method = getattr(self.notifications, "notify_battery_grid_charge_disengaged", None)
+                method = getattr(
+                    self.notifications, "notify_battery_grid_charge_disengaged", None
+                )
                 if method is not None:
                     try:
                         await method(reason)
                     except Exception:
-                        _LOGGER.exception("Failed to send grid_charge_disengaged notification")
+                        _LOGGER.exception(
+                            "Failed to send grid_charge_disengaged notification"
+                        )
 
     @property
     def enabled(self) -> bool:
@@ -580,8 +697,11 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 new_last_change[key] = self._last_state_change[key]
         self._last_state_change = new_last_change
         self._activations_today.clear()
+        self._restored_daily_state.clear()
         self.analytics.reset_daily()
-        _LOGGER.info("Midnight reset: cleared daily runtime, energy, activations, and analytics counters (ON appliances keep switch interval protection)")
+        _LOGGER.info(
+            "Midnight reset: cleared daily runtime, energy, activations, and analytics counters (ON appliances keep switch interval protection)"
+        )
 
     # ------------------------------------------------------------------
     # Main update loop
@@ -597,6 +717,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         # 1. Collect power state from sensors
         power_state = self._collect_power_state()
+
         def _fmt(val: float | None, suffix: str = "W") -> str:
             return f"{val:.0f}{suffix}" if val is not None else "unavailable"
 
@@ -691,7 +812,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # never sheds on_only appliances. So on_only semantics ("don't turn off once
         # started") are preserved during force_charge.
         if self.force_charge:
-            _LOGGER.info("Force charge active: setting large negative excess to trigger shedding")
+            _LOGGER.info(
+                "Force charge active: setting large negative excess to trigger shedding"
+            )
             power_state_for_optimizer = PowerState(
                 pv_production=power_state.pv_production,
                 grid_export=power_state.grid_export,
@@ -722,8 +845,12 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             history_for_optimizer = self.power_history
 
         # Refresh plan_influence and grid_voltage from config each cycle (H12)
-        self._plan_influence = self.config_entry.data.get(CONF_PLAN_INFLUENCE, PlanInfluence.LIGHT)
-        grid_voltage = self.config_entry.data.get(CONF_GRID_VOLTAGE, DEFAULT_GRID_VOLTAGE)
+        self._plan_influence = self.config_entry.data.get(
+            CONF_PLAN_INFLUENCE, PlanInfluence.LIGHT
+        )
+        grid_voltage = self.config_entry.data.get(
+            CONF_GRID_VOLTAGE, DEFAULT_GRID_VOLTAGE
+        )
         self.optimizer.grid_voltage = grid_voltage
         min_battery_soc = self.config_entry.data.get(CONF_MIN_BATTERY_SOC)
 
@@ -755,9 +882,14 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         _LOGGER.debug(
             "Optimizer: %d decisions (ON=%d OFF=%d SET_CURRENT=%d IDLE=%d) "
             "discharge_limit=%s",
-            len(result.decisions), on_count, off_count, set_count, idle_count,
+            len(result.decisions),
+            on_count,
+            off_count,
+            set_count,
+            idle_count,
             result.battery_discharge_action.max_discharge_watts
-            if result.battery_discharge_action.should_limit else "none",
+            if result.battery_discharge_action.should_limit
+            else "none",
         )
         for d in result.decisions:
             _LOGGER.debug("  %s -> %s: %s", d.appliance_id[:12], d.action, d.reason)
@@ -766,7 +898,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # (before applying decisions, so we capture the optimizer's view of the world)
         # Update analytics tariff values each cycle to keep them current
         self.analytics.feed_in_tariff = tariff_info.feed_in_tariff
-        if tariff_info.current_price > tariff_info.cheap_price_threshold and not math.isinf(tariff_info.current_price):
+        if (
+            tariff_info.current_price > tariff_info.cheap_price_threshold
+            and not math.isinf(tariff_info.current_price)
+        ):
             self.analytics.normal_import_price = tariff_info.current_price
         cycle_seconds = self.update_interval.total_seconds()
         for decision in result.decisions:
@@ -779,28 +914,41 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     continue
                 # Use actual power if available, otherwise nominal
                 app_state = appliance_states.get(decision.appliance_id)
-                power = (app_state.current_power if app_state and app_state.current_power > 0
-                         else config.nominal_power if config else 0)
+                power = (
+                    app_state.current_power
+                    if app_state and app_state.current_power > 0
+                    else config.nominal_power
+                    if config
+                    else 0
+                )
                 # M9: Use decision reason to correctly attribute grid-supplemented consumption
                 if "grid supplement" in decision.reason.lower():
                     source = "cheap_tariff"
-                elif power_state.excess_power is not None and power_state.excess_power > 0:
+                elif (
+                    power_state.excess_power is not None
+                    and power_state.excess_power > 0
+                ):
                     source = "solar"
                 elif tariff_info.current_price <= tariff_info.cheap_price_threshold:
                     source = "cheap_tariff"
                 else:
                     source = "grid"
                 self.analytics.record_cycle(
-                    decision.appliance_id, power, cycle_seconds,
-                    source, tariff_info.current_price,
+                    decision.appliance_id,
+                    power,
+                    cycle_seconds,
+                    source,
+                    tariff_info.current_price,
                 )
         if power_state.pv_production is not None:
             self.analytics.record_solar_production(
-                power_state.pv_production, cycle_seconds,
+                power_state.pv_production,
+                cycle_seconds,
             )
         if power_state.grid_export is not None and power_state.grid_export > 0:
             self.analytics.record_grid_export(
-                power_state.grid_export, cycle_seconds,
+                power_state.grid_export,
+                cycle_seconds,
             )
 
         # 10. Apply decisions (call HA services)
@@ -816,13 +964,19 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             prev_state = appliance_states.get(decision.appliance_id)
             if prev_state is None:
                 continue
-            if decision.action in (Action.ON, Action.SET_CURRENT) and not prev_state.is_on:
+            if (
+                decision.action in (Action.ON, Action.SET_CURRENT)
+                and not prev_state.is_on
+            ):
                 await self.notifications.notify_appliance_on(
-                    config.name, decision.reason, config.nominal_power,
+                    config.name,
+                    decision.reason,
+                    config.nominal_power,
                 )
             elif decision.action == Action.OFF and prev_state.is_on:
                 await self.notifications.notify_appliance_off(
-                    config.name, decision.reason,
+                    config.name,
+                    decision.reason,
                 )
 
         return self._build_coordinator_data()
@@ -887,7 +1041,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Power sensors are read with power=True so that kW/MW values are
         # automatically normalised to watts.
         pv_production: float | None = _parse_sensor_float(
-            self.hass, data.get(CONF_PV_POWER), power=True,
+            self.hass,
+            data.get(CONF_PV_POWER),
+            power=True,
         )
         self._track_sensor_availability(data.get(CONF_PV_POWER), pv_production)
 
@@ -900,7 +1056,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if import_export_entity:
             # Combined sensor: positive = export, negative = import.
             combined = _parse_sensor_float(
-                self.hass, import_export_entity, power=True,
+                self.hass,
+                import_export_entity,
+                power=True,
             )
             self._track_sensor_availability(import_export_entity, combined)
             if combined is None:
@@ -911,13 +1069,17 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 grid_import = abs(min(combined, 0.0))
         elif grid_export_entity:
             grid_export = _parse_sensor_float(
-                self.hass, grid_export_entity, power=True,
+                self.hass,
+                grid_export_entity,
+                power=True,
             )
             self._track_sensor_availability(grid_export_entity, grid_export)
             grid_import = 0.0 if grid_export is not None else None
 
         load_power: float | None = _parse_sensor_float(
-            self.hass, data.get(CONF_LOAD_POWER), power=True,
+            self.hass,
+            data.get(CONF_LOAD_POWER),
+            power=True,
         )
         self._track_sensor_availability(data.get(CONF_LOAD_POWER), load_power)
 
@@ -931,15 +1093,27 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if battery_power_entity:
             battery_power = _parse_sensor_float(
-                self.hass, battery_power_entity, power=True,
+                self.hass,
+                battery_power_entity,
+                power=True,
             )
         elif battery_charge_entity or battery_discharge_entity:
-            charge = _parse_sensor_float(
-                self.hass, battery_charge_entity, power=True,
-            ) or 0.0
-            discharge = _parse_sensor_float(
-                self.hass, battery_discharge_entity, power=True,
-            ) or 0.0
+            charge = (
+                _parse_sensor_float(
+                    self.hass,
+                    battery_charge_entity,
+                    power=True,
+                )
+                or 0.0
+            )
+            discharge = (
+                _parse_sensor_float(
+                    self.hass,
+                    battery_discharge_entity,
+                    power=True,
+                )
+                or 0.0
+            )
             battery_power = charge - discharge
 
         # Calculate excess. Branch selection is topology-based and identical
@@ -1047,9 +1221,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # Clamp switch_interval to minimum of 5s to protect against
             # legacy configs that may have stored 0
-            switch_interval = int(max(
-                5, sub_data.get(CONF_SWITCH_INTERVAL, DEFAULT_SWITCH_INTERVAL)
-            ))
+            switch_interval = int(
+                max(5, sub_data.get(CONF_SWITCH_INTERVAL, DEFAULT_SWITCH_INTERVAL))
+            )
 
             config = ApplianceConfig(
                 id=subentry_id,
@@ -1072,10 +1246,14 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ),
                 on_only=sub_data.get(CONF_ON_ONLY, False),
                 min_daily_runtime=(
-                    timedelta(minutes=min_runtime_min) if min_runtime_min is not None else None
+                    timedelta(minutes=min_runtime_min)
+                    if min_runtime_min is not None
+                    else None
                 ),
                 max_daily_runtime=(
-                    timedelta(minutes=max_runtime_min) if max_runtime_min is not None else None
+                    timedelta(minutes=max_runtime_min)
+                    if max_runtime_min is not None
+                    else None
                 ),
                 schedule_deadline=_parse_time_string(deadline_str),
                 start_after=_parse_time_string(sub_data.get(CONF_START_AFTER)),
@@ -1088,12 +1266,16 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 averaging_window=sub_data.get(CONF_AVERAGING_WINDOW),
                 requires_appliance=sub_data.get(CONF_REQUIRES_APPLIANCE),
                 helper_only=sub_data.get(CONF_HELPER_ONLY, False),
-                protect_from_preemption=sub_data.get(CONF_PROTECT_FROM_PREEMPTION, False),
+                protect_from_preemption=sub_data.get(
+                    CONF_PROTECT_FROM_PREEMPTION, False
+                ),
                 current_step=sub_data.get(CONF_CURRENT_STEP, 0.1),
                 override_active=override_active,
                 max_daily_activations=max_activations,
                 on_threshold=sub_data.get(CONF_ON_THRESHOLD),
-                completion_power_threshold=sub_data.get(CONF_COMPLETION_POWER_THRESHOLD),
+                completion_power_threshold=sub_data.get(
+                    CONF_COMPLETION_POWER_THRESHOLD
+                ),
             )
             configs.append(config)
 
@@ -1102,9 +1284,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # in _apply_decisions so it can respond promptly to dependent state
         # transitions. See 2026-04-09-helper-only-hardening-design.md.
         self._needed_by_others = {
-            c.requires_appliance
-            for c in configs
-            if c.requires_appliance
+            c.requires_appliance for c in configs if c.requires_appliance
         }
 
         # Clean up stale entries from all tracking dicts for removed appliances.
@@ -1138,7 +1318,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entity_state = self.hass.states.get(config.entity_id)
             is_on = False
             if entity_state is not None:
-                is_on = entity_state.state not in _OFF_STATES and entity_state.state not in _UNAVAILABLE_STATES
+                is_on = (
+                    entity_state.state not in _OFF_STATES
+                    and entity_state.state not in _UNAVAILABLE_STATES
+                )
 
             # Detect off→on physical transition (Bug A from 2026-04-09
             # incident spec). activations_today is incremented based on
@@ -1156,21 +1339,20 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if config.actual_power_entity:
                 current_power = (
                     _parse_sensor_float(
-                        self.hass, config.actual_power_entity, power=True,
-                    ) or 0.0
+                        self.hass,
+                        config.actual_power_entity,
+                        power=True,
+                    )
+                    or 0.0
                 )
 
             current_amperage: float | None = None
             if config.current_entity:
-                current_amperage = _parse_sensor_float(
-                    self.hass, config.current_entity
-                )
+                current_amperage = _parse_sensor_float(self.hass, config.current_entity)
 
             ev_connected: bool | None = None
             if config.ev_connected_entity:
-                ev_connected = _parse_sensor_bool(
-                    self.hass, config.ev_connected_entity
-                )
+                ev_connected = _parse_sensor_bool(self.hass, config.ev_connected_entity)
 
             ev_soc: float | None = None
             if config.ev_soc_entity:
@@ -1178,8 +1360,17 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # Retrieve and update runtime from stored state
             previous = self.appliance_states.get(config.id)
-            runtime_today = previous.runtime_today if previous else timedelta()
-            energy_today = previous.energy_today if previous else 0.0
+            restored = self._restored_daily_state.get(config.id, {})
+            runtime_today = (
+                previous.runtime_today
+                if previous
+                else timedelta(seconds=float(restored.get("runtime_seconds", 0.0)))
+            )
+            energy_today = (
+                previous.energy_today
+                if previous
+                else float(restored.get("energy_kwh", 0.0))
+            )
             last_state_change = previous.last_state_change if previous else None
 
             # Increment runtime and energy if the appliance is currently ON
@@ -1194,7 +1385,8 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     runtime_today += timedelta(seconds=cycle_seconds)
                 # Energy in kWh: power(W) * time(h)
                 power_for_energy = (
-                    current_power if current_power > 0
+                    current_power
+                    if current_power > 0
                     else (0.0 if config.actual_power_entity else config.nominal_power)
                 )
                 energy_today += (power_for_energy * cycle_seconds) / 3600 / 1000
@@ -1241,9 +1433,10 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # Refresh current_power from the actual power sensor
                 power_entity = sub_data.get(CONF_ACTUAL_POWER_ENTITY)
                 current_power = (
-                    _parse_sensor_float(self.hass, power_entity, power=True)
-                    or 0.0
-                ) if power_entity else 0.0
+                    (_parse_sensor_float(self.hass, power_entity, power=True) or 0.0)
+                    if power_entity
+                    else 0.0
+                )
 
                 states[sub_id] = ApplianceState(
                     appliance_id=old.appliance_id,
@@ -1259,6 +1452,8 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
         self.appliance_states = states
+        self._restored_daily_state.clear()
+        self._schedule_daily_state_save()
         return states
 
     # ------------------------------------------------------------------
@@ -1336,7 +1531,12 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             tariff_info = self._get_tariff_info()
         except Exception as err:
             _LOGGER.warning("Planner: tariff provider error, using defaults: %s", err)
-            tariff_info = TariffInfo(current_price=float("inf"), feed_in_tariff=0.0, cheap_price_threshold=0.0, battery_charge_price_threshold=0.0)
+            tariff_info = TariffInfo(
+                current_price=float("inf"),
+                feed_in_tariff=0.0,
+                cheap_price_threshold=0.0,
+                battery_charge_price_threshold=0.0,
+            )
         appliance_configs = self._get_appliance_configs()
 
         # Battery config
@@ -1421,7 +1621,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 continue
 
             # Skip disabled appliances (unless override is active)
-            if not self.appliance_enabled.get(decision.appliance_id, True) and not self.appliance_overrides.get(decision.appliance_id, False):
+            if not self.appliance_enabled.get(
+                decision.appliance_id, True
+            ) and not self.appliance_overrides.get(decision.appliance_id, False):
                 continue
 
             appliance_config = self._get_appliance_config_by_id(decision.appliance_id)
@@ -1438,17 +1640,24 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 continue
 
             # Check if state actually needs to change
-            is_on = current_state.state not in _OFF_STATES and current_state.state not in _UNAVAILABLE_STATES
+            is_on = (
+                current_state.state not in _OFF_STATES
+                and current_state.state not in _UNAVAILABLE_STATES
+            )
             if decision.action == Action.ON and is_on:
                 _LOGGER.debug(
                     "Skipping %s for %s (%s): already on",
-                    decision.action, appliance_config.name, entity_id,
+                    decision.action,
+                    appliance_config.name,
+                    entity_id,
                 )
                 continue  # Already on, skip
             if decision.action == Action.OFF and not is_on:
                 _LOGGER.debug(
                     "Skipping %s for %s (%s): already off",
-                    decision.action, appliance_config.name, entity_id,
+                    decision.action,
+                    appliance_config.name,
+                    entity_id,
                 )
                 continue  # Already off, skip
 
@@ -1468,40 +1677,54 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             #     (they may need to respond promptly to dependent transitions —
             #     see 2026-04-09-helper-only-hardening-design.md Bug C).
             is_needed_by_others = decision.appliance_id in self._needed_by_others
-            if not decision.bypasses_cooldown and not is_needed_by_others:
-                if decision.action != Action.SET_CURRENT or not is_on:
-                    last_change = self._last_state_change.get(decision.appliance_id)
-                    if last_change is not None:
-                        elapsed = (datetime.now() - last_change).total_seconds()
-                        if elapsed < appliance_config.switch_interval:
-                            _LOGGER.debug(
-                                "Skipping %s for %s (%s): switch interval not elapsed "
-                                "(%.0fs of %ds)",
-                                decision.action, appliance_config.name, entity_id,
-                                elapsed, appliance_config.switch_interval,
-                            )
-                            continue  # Too soon to change
+            if (
+                not decision.bypasses_cooldown
+                and not is_needed_by_others
+                and (decision.action != Action.SET_CURRENT or not is_on)
+            ):
+                last_change = self._last_state_change.get(decision.appliance_id)
+                if last_change is not None:
+                    elapsed = (datetime.now() - last_change).total_seconds()
+                    if elapsed < appliance_config.switch_interval:
+                        _LOGGER.debug(
+                            "Skipping %s for %s (%s): switch interval not elapsed "
+                            "(%.0fs of %ds)",
+                            decision.action,
+                            appliance_config.name,
+                            entity_id,
+                            elapsed,
+                            appliance_config.switch_interval,
+                        )
+                        continue  # Too soon to change
 
             try:
                 if decision.action == Action.ON:
                     try:
                         async with asyncio.timeout(10):
                             await self.hass.services.async_call(
-                                domain, "turn_on", {"entity_id": entity_id},
+                                domain,
+                                "turn_on",
+                                {"entity_id": entity_id},
                                 blocking=True,
                             )
                     except (TimeoutError, Exception) as err:
-                        _LOGGER.error("Failed to turn on %s: %s", appliance_config.name, err)
+                        _LOGGER.error(
+                            "Failed to turn on %s: %s", appliance_config.name, err
+                        )
                         continue
                 elif decision.action == Action.OFF:
                     try:
                         async with asyncio.timeout(10):
                             await self.hass.services.async_call(
-                                domain, "turn_off", {"entity_id": entity_id},
+                                domain,
+                                "turn_off",
+                                {"entity_id": entity_id},
                                 blocking=True,
                             )
                     except (TimeoutError, Exception) as err:
-                        _LOGGER.error("Failed to turn off %s: %s", appliance_config.name, err)
+                        _LOGGER.error(
+                            "Failed to turn off %s: %s", appliance_config.name, err
+                        )
                         continue
                     self._last_applied_current.pop(decision.appliance_id, None)
                 elif decision.action == Action.SET_CURRENT:
@@ -1513,11 +1736,13 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         # H3: Skip entirely if same current already applied and appliance is on
                         if (
                             is_on
-                            and decision.target_current == self._last_applied_current.get(decision.appliance_id)
+                            and decision.target_current
+                            == self._last_applied_current.get(decision.appliance_id)
                         ):
                             _LOGGER.debug(
                                 "Skipping SET_CURRENT for %s: current %.1fA already applied",
-                                appliance_config.name, decision.target_current,
+                                appliance_config.name,
+                                decision.target_current,
                             )
                             continue
 
@@ -1539,22 +1764,34 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                     blocking=True,
                                 )
                         except (TimeoutError, Exception) as err:
-                            _LOGGER.error("Failed to set current for %s: %s", appliance_config.name, err)
+                            _LOGGER.error(
+                                "Failed to set current for %s: %s",
+                                appliance_config.name,
+                                err,
+                            )
                             continue
 
                         # Track last applied current for deduplication
-                        self._last_applied_current[decision.appliance_id] = decision.target_current
+                        self._last_applied_current[decision.appliance_id] = (
+                            decision.target_current
+                        )
 
                         # H2: Only call turn_on if the appliance is not already on
                         if not is_on:
                             try:
                                 async with asyncio.timeout(10):
                                     await self.hass.services.async_call(
-                                        domain, "turn_on", {"entity_id": entity_id},
+                                        domain,
+                                        "turn_on",
+                                        {"entity_id": entity_id},
                                         blocking=True,
                                     )
                             except (TimeoutError, Exception) as err:
-                                _LOGGER.warning("Current set but turn_on failed for %s: %s", appliance_config.name, err)
+                                _LOGGER.warning(
+                                    "Current set but turn_on failed for %s: %s",
+                                    appliance_config.name,
+                                    err,
+                                )
                                 continue  # Don't record as applied
                     else:
                         _LOGGER.warning(
@@ -1574,7 +1811,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 applied_ids.append(decision.appliance_id)
                 _LOGGER.info(
                     "Applied %s to %s (%s): %s",
-                    decision.action, appliance_config.name, entity_id,
+                    decision.action,
+                    appliance_config.name,
+                    entity_id,
                     decision.reason,
                 )
             except Exception as err:
@@ -1642,9 +1881,7 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # Helpers
     # ------------------------------------------------------------------
 
-    def _get_appliance_config_by_id(
-        self, appliance_id: str
-    ) -> ApplianceConfig | None:
+    def _get_appliance_config_by_id(self, appliance_id: str) -> ApplianceConfig | None:
         """Look up an appliance config by its subentry ID."""
         subentries = getattr(self.config_entry, "subentries", {})
         subentry = subentries.get(appliance_id)
@@ -1687,17 +1924,21 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ),
             on_only=sub_data.get(CONF_ON_ONLY, False),
             min_daily_runtime=(
-                timedelta(minutes=min_runtime_min) if min_runtime_min is not None else None
+                timedelta(minutes=min_runtime_min)
+                if min_runtime_min is not None
+                else None
             ),
             max_daily_runtime=(
-                timedelta(minutes=max_runtime_min) if max_runtime_min is not None else None
+                timedelta(minutes=max_runtime_min)
+                if max_runtime_min is not None
+                else None
             ),
             schedule_deadline=_parse_time_string(deadline_str),
             start_after=_parse_time_string(sub_data.get(CONF_START_AFTER)),
             end_before=_parse_time_string(sub_data.get(CONF_END_BEFORE)),
-            switch_interval=int(max(
-                5, sub_data.get(CONF_SWITCH_INTERVAL, DEFAULT_SWITCH_INTERVAL)
-            )),
+            switch_interval=int(
+                max(5, sub_data.get(CONF_SWITCH_INTERVAL, DEFAULT_SWITCH_INTERVAL))
+            ),
             allow_grid_supplement=sub_data.get(CONF_ALLOW_GRID_SUPPLEMENT, False),
             max_grid_power=sub_data.get(CONF_MAX_GRID_POWER),
             cheap_grid_target_current=sub_data.get(CONF_CHEAP_GRID_TARGET_CURRENT),
@@ -1730,22 +1971,31 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             current_state = self.hass.states.get(entity_id)
             if current_state is None:
                 continue
-            if current_state.state in _OFF_STATES or current_state.state in _UNAVAILABLE_STATES:
+            if (
+                current_state.state in _OFF_STATES
+                or current_state.state in _UNAVAILABLE_STATES
+            ):
                 continue
             domain = entity_id.split(".")[0] if "." in entity_id else "switch"
             name = subentry.data.get(CONF_APPLIANCE_NAME, subentry_id)
             try:
                 async with asyncio.timeout(10):
                     await self.hass.services.async_call(
-                        domain, "turn_off", {"entity_id": entity_id},
+                        domain,
+                        "turn_off",
+                        {"entity_id": entity_id},
                         blocking=True,
                     )
-                _LOGGER.info("Master switch disabled: turned off %s (%s)", name, entity_id)
+                _LOGGER.info(
+                    "Master switch disabled: turned off %s (%s)", name, entity_id
+                )
             except (TimeoutError, Exception) as err:
                 _LOGGER.error("Failed to turn off %s on master disable: %s", name, err)
 
         # Reset battery discharge limit to default (no limiting)
-        await self._apply_battery_discharge_limit(BatteryDischargeAction(should_limit=False))
+        await self._apply_battery_discharge_limit(
+            BatteryDischargeAction(should_limit=False)
+        )
 
     def _create_empty_plan(self) -> Plan:
         """Create an empty plan with no entries."""
@@ -1770,7 +2020,9 @@ class PvExcessCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Compute remaining startup grace period in seconds (None when elapsed)
         elapsed = (datetime.now() - self._startup_time).total_seconds()
         if elapsed < DEFAULT_STARTUP_GRACE_PERIOD:
-            grace_period_remaining: float | None = DEFAULT_STARTUP_GRACE_PERIOD - elapsed
+            grace_period_remaining: float | None = (
+                DEFAULT_STARTUP_GRACE_PERIOD - elapsed
+            )
         else:
             grace_period_remaining = None
 

--- a/custom_components/pv_excess_control/energy.py
+++ b/custom_components/pv_excess_control/energy.py
@@ -3,15 +3,18 @@
 HA-agnostic: providers accept state dicts (entity_id -> {state, attributes})
 rather than HA objects, making them straightforwardly unit-testable.
 """
+
 from __future__ import annotations
 
 import logging
 import math
 from abc import ABC, abstractmethod
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from custom_components.pv_excess_control.const import TariffProvider as TariffProviderEnum
+from custom_components.pv_excess_control.const import (
+    TariffProvider as TariffProviderEnum,
+)
 from custom_components.pv_excess_control.models import TariffInfo, TariffWindow
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,7 +47,9 @@ def _parse_dt(value: str | datetime) -> datetime:
     return datetime.fromisoformat(value)
 
 
-def _make_window(start: datetime, end: datetime, price: float, threshold: float) -> TariffWindow:
+def _make_window(
+    start: datetime, end: datetime, price: float, threshold: float
+) -> TariffWindow:
     """Create a TariffWindow with is_cheap derived from price <= threshold."""
     return TariffWindow(start=start, end=end, price=price, is_cheap=price <= threshold)
 
@@ -52,6 +57,7 @@ def _make_window(start: datetime, end: datetime, price: float, threshold: float)
 # ---------------------------------------------------------------------------
 # Abstract base
 # ---------------------------------------------------------------------------
+
 
 class TariffProvider(ABC):
     """Base class for tariff providers."""
@@ -81,6 +87,7 @@ class TariffProvider(ABC):
 # GenericTariffProvider
 # ---------------------------------------------------------------------------
 
+
 class GenericTariffProvider(TariffProvider):
     """Reads current price from any HA sensor.
 
@@ -104,7 +111,10 @@ class GenericTariffProvider(TariffProvider):
         entity = states.get(self.price_entity)
         if entity is None:
             if self.price_entity:
-                _LOGGER.warning("TariffProvider: entity %s not found in states, using fallback price inf", self.price_entity)
+                _LOGGER.warning(
+                    "TariffProvider: entity %s not found in states, using fallback price inf",
+                    self.price_entity,
+                )
             return TariffInfo(
                 current_price=float("inf"),
                 feed_in_tariff=feed_in_tariff,
@@ -115,7 +125,11 @@ class GenericTariffProvider(TariffProvider):
         raw_state = str(entity.get("state", ""))
         parsed_price = _parse_price(raw_state)
         if parsed_price is None:
-            _LOGGER.warning("TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf", self.price_entity, raw_state)
+            _LOGGER.warning(
+                "TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf",
+                self.price_entity,
+                raw_state,
+            )
             current_price = float("inf")
         else:
             current_price = parsed_price
@@ -135,7 +149,10 @@ class GenericTariffProvider(TariffProvider):
 
         _LOGGER.debug(
             "GenericTariff: entity=%s raw_state=%s -> price=%s windows=%d",
-            self.price_entity, raw_state, current_price, len(windows),
+            self.price_entity,
+            raw_state,
+            current_price,
+            len(windows),
         )
         return TariffInfo(
             current_price=current_price,
@@ -149,6 +166,7 @@ class GenericTariffProvider(TariffProvider):
 # ---------------------------------------------------------------------------
 # TibberProvider
 # ---------------------------------------------------------------------------
+
 
 class TibberProvider(TariffProvider):
     """Reads Tibber price data.
@@ -170,7 +188,10 @@ class TibberProvider(TariffProvider):
     ) -> TariffInfo:
         entity = states.get(self.price_entity)
         if entity is None:
-            _LOGGER.warning("TariffProvider: entity %s not found in states, using fallback price inf", self.price_entity)
+            _LOGGER.warning(
+                "TariffProvider: entity %s not found in states, using fallback price inf",
+                self.price_entity,
+            )
             return TariffInfo(
                 current_price=float("inf"),
                 feed_in_tariff=feed_in_tariff,
@@ -181,7 +202,11 @@ class TibberProvider(TariffProvider):
         raw_state = str(entity.get("state", ""))
         parsed_price = _parse_price(raw_state)
         if parsed_price is None:
-            _LOGGER.warning("TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf", self.price_entity, raw_state)
+            _LOGGER.warning(
+                "TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf",
+                self.price_entity,
+                raw_state,
+            )
             current_price = float("inf")
         else:
             current_price = parsed_price
@@ -194,7 +219,9 @@ class TibberProvider(TariffProvider):
                 start = _parse_dt(entry["startsAt"])
                 end = start + timedelta(hours=1)
                 price = float(entry["total"])
-                today_windows.append(_make_window(start, end, price, cheap_price_threshold))
+                today_windows.append(
+                    _make_window(start, end, price, cheap_price_threshold)
+                )
             except (KeyError, ValueError, TypeError):
                 pass
         for entry in attributes.get("tomorrow", []):
@@ -202,14 +229,19 @@ class TibberProvider(TariffProvider):
                 start = _parse_dt(entry["startsAt"])
                 end = start + timedelta(hours=1)
                 price = float(entry["total"])
-                tomorrow_windows.append(_make_window(start, end, price, cheap_price_threshold))
+                tomorrow_windows.append(
+                    _make_window(start, end, price, cheap_price_threshold)
+                )
             except (KeyError, ValueError, TypeError):
                 pass
 
         windows = today_windows + tomorrow_windows
         _LOGGER.debug(
             "Tibber: entity=%s price=%.4f windows_today=%d windows_tomorrow=%d",
-            self.price_entity, current_price, len(today_windows), len(tomorrow_windows),
+            self.price_entity,
+            current_price,
+            len(today_windows),
+            len(tomorrow_windows),
         )
         return TariffInfo(
             current_price=current_price,
@@ -223,6 +255,7 @@ class TibberProvider(TariffProvider):
 # ---------------------------------------------------------------------------
 # AwattarProvider
 # ---------------------------------------------------------------------------
+
 
 class AwattarProvider(TariffProvider):
     """Reads aWATTar spot prices.
@@ -247,7 +280,10 @@ class AwattarProvider(TariffProvider):
     ) -> TariffInfo:
         entity = states.get(self.price_entity)
         if entity is None:
-            _LOGGER.warning("TariffProvider: entity %s not found in states, using fallback price inf", self.price_entity)
+            _LOGGER.warning(
+                "TariffProvider: entity %s not found in states, using fallback price inf",
+                self.price_entity,
+            )
             return TariffInfo(
                 current_price=float("inf"),
                 feed_in_tariff=feed_in_tariff,
@@ -258,7 +294,11 @@ class AwattarProvider(TariffProvider):
         raw_state = str(entity.get("state", ""))
         parsed_price = _parse_price(raw_state)
         if parsed_price is None:
-            _LOGGER.warning("TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf", self.price_entity, raw_state)
+            _LOGGER.warning(
+                "TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf",
+                self.price_entity,
+                raw_state,
+            )
             current_price = float("inf")
         else:
             # State is in cents; convert to EUR
@@ -272,13 +312,18 @@ class AwattarProvider(TariffProvider):
                 start = _parse_dt(entry["start_time"])
                 end = _parse_dt(entry["end_time"])
                 price_eur = float(entry["price_ct_per_kwh"]) / 100.0
-                windows.append(_make_window(start, end, price_eur, cheap_price_threshold))
+                windows.append(
+                    _make_window(start, end, price_eur, cheap_price_threshold)
+                )
             except (KeyError, ValueError, TypeError):
                 pass
 
         _LOGGER.debug(
             "Awattar: entity=%s raw_state=%s -> price=%.4f windows=%d",
-            self.price_entity, raw_state, current_price, len(windows),
+            self.price_entity,
+            raw_state,
+            current_price,
+            len(windows),
         )
         return TariffInfo(
             current_price=current_price,
@@ -292,6 +337,7 @@ class AwattarProvider(TariffProvider):
 # ---------------------------------------------------------------------------
 # NordpoolProvider
 # ---------------------------------------------------------------------------
+
 
 class NordpoolProvider(TariffProvider):
     """Reads Nordpool spot prices.
@@ -323,7 +369,10 @@ class NordpoolProvider(TariffProvider):
     ) -> TariffInfo:
         entity = states.get(self.price_entity)
         if entity is None:
-            _LOGGER.warning("TariffProvider: entity %s not found in states, using fallback price inf", self.price_entity)
+            _LOGGER.warning(
+                "TariffProvider: entity %s not found in states, using fallback price inf",
+                self.price_entity,
+            )
             return TariffInfo(
                 current_price=float("inf"),
                 feed_in_tariff=feed_in_tariff,
@@ -334,7 +383,11 @@ class NordpoolProvider(TariffProvider):
         raw_state = str(entity.get("state", ""))
         parsed_price = _parse_price(raw_state)
         if parsed_price is None:
-            _LOGGER.warning("TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf", self.price_entity, raw_state)
+            _LOGGER.warning(
+                "TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf",
+                self.price_entity,
+                raw_state,
+            )
             current_price = float("inf")
         else:
             current_price = parsed_price
@@ -358,13 +411,18 @@ class NordpoolProvider(TariffProvider):
                 try:
                     start = midnight + timedelta(hours=hour_idx)
                     end = start + timedelta(hours=1)
-                    windows.append(_make_window(start, end, float(price), cheap_price_threshold))
+                    windows.append(
+                        _make_window(start, end, float(price), cheap_price_threshold)
+                    )
                 except (ValueError, TypeError):
                     pass
 
         _LOGGER.debug(
             "Nordpool: entity=%s raw_state=%s -> price=%.4f windows=%d",
-            self.price_entity, raw_state, current_price, len(windows),
+            self.price_entity,
+            raw_state,
+            current_price,
+            len(windows),
         )
         return TariffInfo(
             current_price=current_price,
@@ -378,6 +436,7 @@ class NordpoolProvider(TariffProvider):
 # ---------------------------------------------------------------------------
 # OctopusProvider
 # ---------------------------------------------------------------------------
+
 
 class OctopusProvider(TariffProvider):
     """Reads Octopus Energy tariff data.
@@ -398,7 +457,10 @@ class OctopusProvider(TariffProvider):
     ) -> TariffInfo:
         entity = states.get(self.price_entity)
         if entity is None:
-            _LOGGER.warning("TariffProvider: entity %s not found in states, using fallback price inf", self.price_entity)
+            _LOGGER.warning(
+                "TariffProvider: entity %s not found in states, using fallback price inf",
+                self.price_entity,
+            )
             return TariffInfo(
                 current_price=float("inf"),
                 feed_in_tariff=feed_in_tariff,
@@ -409,7 +471,11 @@ class OctopusProvider(TariffProvider):
         raw_state = str(entity.get("state", ""))
         parsed_price = _parse_price(raw_state)
         if parsed_price is None:
-            _LOGGER.warning("TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf", self.price_entity, raw_state)
+            _LOGGER.warning(
+                "TariffProvider: entity %s state is unavailable/unknown ('%s'), using fallback price inf",
+                self.price_entity,
+                raw_state,
+            )
             current_price = float("inf")
         else:
             current_price = parsed_price
@@ -433,7 +499,10 @@ class OctopusProvider(TariffProvider):
 
         _LOGGER.debug(
             "Octopus: entity=%s raw_state=%s -> price=%.4f windows=%d",
-            self.price_entity, raw_state, current_price, len(windows),
+            self.price_entity,
+            raw_state,
+            current_price,
+            len(windows),
         )
         return TariffInfo(
             current_price=current_price,
@@ -447,6 +516,7 @@ class OctopusProvider(TariffProvider):
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
+
 
 def create_tariff_provider(
     provider_type: str,

--- a/custom_components/pv_excess_control/forecast.py
+++ b/custom_components/pv_excess_control/forecast.py
@@ -3,6 +3,7 @@
 Supports Solcast, Forecast.Solar, and generic sensor providers.
 Designed to be HA-agnostic: accepts raw state dicts, not HA objects.
 """
+
 from __future__ import annotations
 
 import logging
@@ -49,14 +50,19 @@ class GenericForecastProvider(ForecastProvider):
     def get_forecast(self, states: dict[str, dict]) -> ForecastData:
         entity_state = states.get(self.forecast_entity)
         if entity_state is None:
-            _LOGGER.warning("ForecastProvider: entity %s state is unavailable/unknown", self.forecast_entity)
+            _LOGGER.warning(
+                "ForecastProvider: entity %s state is unavailable/unknown",
+                self.forecast_entity,
+            )
             return ForecastData(remaining_today_kwh=0.0)
 
         raw_state = entity_state.get("state", "unavailable")
         remaining = _safe_float(raw_state)
         _LOGGER.debug(
             "GenericForecast: entity=%s raw_state=%s -> remaining=%.2f kWh",
-            self.forecast_entity, raw_state, remaining,
+            self.forecast_entity,
+            raw_state,
+            remaining,
         )
         return ForecastData(remaining_today_kwh=remaining)
 
@@ -77,7 +83,10 @@ class SolcastProvider(ForecastProvider):
     def get_forecast(self, states: dict[str, dict]) -> ForecastData:
         entity_state = states.get(self.forecast_entity)
         if entity_state is None:
-            _LOGGER.warning("ForecastProvider: entity %s state is unavailable/unknown", self.forecast_entity)
+            _LOGGER.warning(
+                "ForecastProvider: entity %s state is unavailable/unknown",
+                self.forecast_entity,
+            )
             return ForecastData(remaining_today_kwh=0.0)
 
         state_val = entity_state.get("state", "unavailable")
@@ -99,7 +108,9 @@ class SolcastProvider(ForecastProvider):
             )
         tomorrow_raw = attributes.get("forecast_tomorrow")
         try:
-            tomorrow_kwh: float | None = float(tomorrow_raw) if tomorrow_raw is not None else None
+            tomorrow_kwh: float | None = (
+                float(tomorrow_raw) if tomorrow_raw is not None else None
+            )
         except (ValueError, TypeError):
             _LOGGER.warning("Solcast: forecast_tomorrow not numeric: %r", tomorrow_raw)
             tomorrow_kwh = None
@@ -108,7 +119,10 @@ class SolcastProvider(ForecastProvider):
 
         _LOGGER.debug(
             "Solcast: entity=%s remaining=%.2f kWh hourly_slots=%d tomorrow=%.2f kWh",
-            self.forecast_entity, remaining, len(hourly_breakdown), tomorrow_kwh or 0,
+            self.forecast_entity,
+            remaining,
+            len(hourly_breakdown),
+            tomorrow_kwh or 0,
         )
         return ForecastData(
             remaining_today_kwh=remaining,
@@ -140,8 +154,13 @@ class SolcastProvider(ForecastProvider):
                 continue
 
             # Truncate to the calendar hour
-            hour_key = (dt.year, dt.month, dt.day, dt.hour,
-                        dt.tzinfo.utcoffset(dt) if dt.tzinfo else None)
+            hour_key = (
+                dt.year,
+                dt.month,
+                dt.day,
+                dt.hour,
+                dt.tzinfo.utcoffset(dt) if dt.tzinfo else None,
+            )
             hour_dt = dt.replace(minute=0, second=0, microsecond=0)
 
             if hour_key not in hour_start:
@@ -162,12 +181,14 @@ class SolcastProvider(ForecastProvider):
             kwh = hour_kwh[hour_key]
             # Average watts = average kW * 1000
             avg_kw = hour_kw_sum[hour_key] / hour_count[hour_key]
-            result.append(HourlyForecast(
-                start=start_dt,
-                end=end_dt,
-                expected_kwh=kwh,
-                expected_watts=avg_kw * 1000.0,
-            ))
+            result.append(
+                HourlyForecast(
+                    start=start_dt,
+                    end=end_dt,
+                    expected_kwh=kwh,
+                    expected_watts=avg_kw * 1000.0,
+                )
+            )
 
         return result
 
@@ -187,7 +208,10 @@ class ForecastSolarProvider(ForecastProvider):
     def get_forecast(self, states: dict[str, dict]) -> ForecastData:
         entity_state = states.get(self.forecast_entity)
         if entity_state is None:
-            _LOGGER.warning("ForecastProvider: entity %s state is unavailable/unknown", self.forecast_entity)
+            _LOGGER.warning(
+                "ForecastProvider: entity %s state is unavailable/unknown",
+                self.forecast_entity,
+            )
             return ForecastData(remaining_today_kwh=0.0)
 
         state_val = entity_state.get("state", "unavailable")
@@ -204,10 +228,11 @@ class ForecastSolarProvider(ForecastProvider):
         wh_days = attributes.get("wh_days", {})
         if wh_days:
             from datetime import date, timedelta as td
+
             tomorrow_date = date.today() + td(days=1)
             for key, wh_value in wh_days.items():
                 try:
-                    if hasattr(key, 'date'):
+                    if hasattr(key, "date"):
                         key_date = key.date()
                     else:
                         key_date = date.fromisoformat(str(key))
@@ -219,7 +244,9 @@ class ForecastSolarProvider(ForecastProvider):
 
         _LOGGER.debug(
             "ForecastSolar: entity=%s remaining=%.2f kWh watts_entries=%d tomorrow=%.2f kWh",
-            self.forecast_entity, remaining, len(watts_dict) if watts_dict else 0,
+            self.forecast_entity,
+            remaining,
+            len(watts_dict) if watts_dict else 0,
             tomorrow_total_kwh or 0,
         )
         return ForecastData(
@@ -242,12 +269,14 @@ class ForecastSolarProvider(ForecastProvider):
             watts = float(watts_value)
             kwh = watts / 1000.0  # average watts over 1 hour -> kWh
 
-            result.append(HourlyForecast(
-                start=dt,
-                end=dt + timedelta(hours=1),
-                expected_kwh=kwh,
-                expected_watts=watts,
-            ))
+            result.append(
+                HourlyForecast(
+                    start=dt,
+                    end=dt + timedelta(hours=1),
+                    expected_kwh=kwh,
+                    expected_watts=watts,
+                )
+            )
 
         # Sort chronologically
         result.sort(key=lambda hf: hf.start)
@@ -268,7 +297,9 @@ def _parse_iso(value) -> datetime | None:
         return None
 
 
-def create_forecast_provider(provider_type: str, forecast_entity: str) -> ForecastProvider:
+def create_forecast_provider(
+    provider_type: str, forecast_entity: str
+) -> ForecastProvider:
     """Create a forecast provider by type string.
 
     Args:

--- a/custom_components/pv_excess_control/helpers.py
+++ b/custom_components/pv_excess_control/helpers.py
@@ -1,4 +1,5 @@
 """Sensor combiner helpers for multi-inverter/battery setups."""
+
 from __future__ import annotations
 
 import logging
@@ -35,7 +36,7 @@ class SensorCombiner:
             raise ValueError("values and weights must have same length")
         total_weight = 0.0
         weighted_sum = 0.0
-        for i, (val, weight) in enumerate(zip(values, weights)):
+        for i, (val, weight) in enumerate(zip(values, weights, strict=False)):
             if val is None:
                 label = labels[i] if labels and i < len(labels) else f"sensor_{i}"
                 _LOGGER.warning("Sensor %s unavailable, skipping in average", label)

--- a/custom_components/pv_excess_control/inverter_control.py
+++ b/custom_components/pv_excess_control/inverter_control.py
@@ -8,6 +8,7 @@ Engage order: mode → power → command.
 Disengage order: command → mode (power entity is left untouched to
 preserve a user-set value).
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,7 +19,9 @@ from .models import InverterGridChargeConfig
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORTED_ENABLE_DOMAINS = frozenset({"input_select", "select", "switch", "input_boolean"})
+SUPPORTED_ENABLE_DOMAINS = frozenset(
+    {"input_select", "select", "switch", "input_boolean"}
+)
 SUPPORTED_POWER_DOMAINS = frozenset({"input_number", "number"})
 
 _TRUTHY_STRINGS = frozenset({"on", "true", "1", "yes"})
@@ -55,41 +58,58 @@ class InverterGridChargeController:
     async def engage(self, power_w: float) -> None:
         """Command the inverter into forced grid-charge."""
         if self._config.mode_entity_id is not None:
-            await self._write(self._config.mode_entity_id, self._config.mode_engage_value)
+            await self._write(
+                self._config.mode_entity_id, self._config.mode_engage_value
+            )
         if self._config.power_entity_id is not None:
             await self._write(self._config.power_entity_id, float(power_w))
-        await self._write(self._config.enable_entity_id, self._config.enable_engage_value)
+        await self._write(
+            self._config.enable_entity_id, self._config.enable_engage_value
+        )
 
     async def disengage(self) -> None:
         """Revert to self-consumption / stop forced charge."""
-        await self._write(self._config.enable_entity_id, self._config.enable_disengage_value)
+        await self._write(
+            self._config.enable_entity_id, self._config.enable_disengage_value
+        )
         if self._config.mode_entity_id is not None:
-            await self._write(self._config.mode_entity_id, self._config.mode_disengage_value)
+            await self._write(
+                self._config.mode_entity_id, self._config.mode_disengage_value
+            )
         # Intentionally do not touch power_entity on disengage.
 
     async def _write(self, entity_id: str, value) -> None:
         domain = self._domain(entity_id)
         if domain in {"input_select", "select"}:
             await self._hass.services.async_call(
-                domain, "select_option",
+                domain,
+                "select_option",
                 {"entity_id": entity_id, "option": str(value)},
                 blocking=False,
             )
         elif domain in {"input_number", "number"}:
             await self._hass.services.async_call(
-                domain, "set_value",
+                domain,
+                "set_value",
                 {"entity_id": entity_id, "value": float(value)},
                 blocking=False,
             )
         elif domain in {"switch", "input_boolean"}:
-            service = "turn_on" if str(value).strip().lower() in _TRUTHY_STRINGS else "turn_off"
+            service = (
+                "turn_on"
+                if str(value).strip().lower() in _TRUTHY_STRINGS
+                else "turn_off"
+            )
             await self._hass.services.async_call(
-                domain, service,
+                domain,
+                service,
                 {"entity_id": entity_id},
                 blocking=False,
             )
         else:
-            raise ValueError(f"Unsupported entity domain for inverter grid charge: {domain}")
+            raise ValueError(
+                f"Unsupported entity domain for inverter grid charge: {domain}"
+            )
 
     @staticmethod
     def _domain(entity_id: str) -> str:

--- a/custom_components/pv_excess_control/manifest.json
+++ b/custom_components/pv_excess_control/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/InventoCasa/PV-Excess-Control",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/InventoCasa/PV-Excess-Control/issues",
-  "version": "0.4.0b3",
+  "version": "0.4.0b4",
   "homeassistant": "2025.8.0"
 }

--- a/custom_components/pv_excess_control/manifest.json
+++ b/custom_components/pv_excess_control/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/InventoCasa/PV-Excess-Control",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/InventoCasa/PV-Excess-Control/issues",
-  "version": "0.4.0b1",
+  "version": "0.4.0b2",
   "homeassistant": "2025.8.0"
 }

--- a/custom_components/pv_excess_control/manifest.json
+++ b/custom_components/pv_excess_control/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/InventoCasa/PV-Excess-Control",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/InventoCasa/PV-Excess-Control/issues",
-  "version": "0.3.0",
+  "version": "0.4.0b1",
   "homeassistant": "2025.8.0"
 }

--- a/custom_components/pv_excess_control/manifest.json
+++ b/custom_components/pv_excess_control/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/InventoCasa/PV-Excess-Control",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/InventoCasa/PV-Excess-Control/issues",
-  "version": "0.4.0b4",
+  "version": "0.4.0b5",
   "homeassistant": "2025.8.0"
 }

--- a/custom_components/pv_excess_control/manifest.json
+++ b/custom_components/pv_excess_control/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/InventoCasa/PV-Excess-Control",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/InventoCasa/PV-Excess-Control/issues",
-  "version": "0.4.0b2",
+  "version": "0.4.0b3",
   "homeassistant": "2025.8.0"
 }

--- a/custom_components/pv_excess_control/models.py
+++ b/custom_components/pv_excess_control/models.py
@@ -1,4 +1,5 @@
 """Data models for PV Excess Control. Pure Python - no HA dependencies."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -10,6 +11,7 @@ from .const import Action, BatteryStrategy, PlanReason
 @dataclass
 class HourlyForecast:
     """Expected solar production for a specific hour."""
+
     start: datetime
     end: datetime
     expected_kwh: float
@@ -19,6 +21,7 @@ class HourlyForecast:
 @dataclass
 class ForecastData:
     """Normalized forecast data from any provider."""
+
     remaining_today_kwh: float
     hourly_breakdown: list[HourlyForecast] = field(default_factory=list)
     tomorrow_total_kwh: float | None = None
@@ -33,6 +36,7 @@ class PowerState:
     taken, while ``0.0`` means the sensor reported a genuine zero.
     Downstream consumers must not conflate the two.
     """
+
     pv_production: float | None
     grid_export: float | None
     grid_import: float | None
@@ -47,6 +51,7 @@ class PowerState:
 @dataclass
 class ApplianceConfig:
     """Configuration for a managed appliance."""
+
     id: str
     name: str
     entity_id: str
@@ -83,12 +88,18 @@ class ApplianceConfig:
     max_grid_power: float | None
 
     # Fields with defaults (must come after non-default fields)
-    cheap_price_threshold: float | None = None  # Per-appliance cheap threshold; None = use global
+    cheap_price_threshold: float | None = (
+        None  # Per-appliance cheap threshold; None = use global
+    )
     ev_target_soc: float | None = None
     start_after: time | None = None
     end_before: time | None = None
-    averaging_window: int | None = None  # Per-appliance history window in seconds (None = use global)
-    requires_appliance: str | None = None  # Subentry ID of required dependency appliance
+    averaging_window: int | None = (
+        None  # Per-appliance history window in seconds (None = use global)
+    )
+    requires_appliance: str | None = (
+        None  # Subentry ID of required dependency appliance
+    )
     helper_only: bool = False  # If True, this appliance runs only when at least one dependent (an appliance with requires_appliance pointing at it) is running. Has no effect on its own allocation.
     override_active: bool = False
     override_until: datetime | None = None
@@ -118,6 +129,7 @@ class ApplianceConfig:
 @dataclass
 class ApplianceState:
     """Runtime state of a managed appliance."""
+
     appliance_id: str
     is_on: bool
     current_power: float
@@ -133,6 +145,7 @@ class ApplianceState:
 @dataclass(frozen=True)
 class TariffWindow:
     """A time window with an energy price."""
+
     start: datetime
     end: datetime
     price: float
@@ -142,6 +155,7 @@ class TariffWindow:
 @dataclass
 class TariffInfo:
     """Current tariff context for the optimizer."""
+
     current_price: float
     feed_in_tariff: float
     cheap_price_threshold: float
@@ -157,6 +171,7 @@ class TariffInfo:
 @dataclass(frozen=True)
 class BatteryTarget:
     """Battery charging strategy for the planning horizon."""
+
     target_soc: float
     target_time: datetime
     strategy: BatteryStrategy
@@ -165,6 +180,7 @@ class BatteryTarget:
 @dataclass(frozen=True)
 class BatteryConfig:
     """Battery system configuration."""
+
     capacity_kwh: float
     max_discharge_entity: str | None
     max_discharge_default: float | None
@@ -177,6 +193,7 @@ class BatteryConfig:
 @dataclass
 class TimeSlot:
     """A planning time slot with expected conditions."""
+
     start: datetime
     end: datetime
     expected_solar_watts: float  # Expected PV production
@@ -188,14 +205,18 @@ class TimeSlot:
 @dataclass
 class BatteryAllocation:
     """How battery charging should be allocated across the timeline."""
+
     charging_needed_kwh: float  # Total energy needed to reach target
     slots_reserved: list[TimeSlot]  # Slots where excess is reserved for battery
-    excess_after_battery: dict[int, float]  # slot_index -> remaining excess after battery allocation
+    excess_after_battery: dict[
+        int, float
+    ]  # slot_index -> remaining excess after battery allocation
 
 
 @dataclass(frozen=True)
 class PlanEntry:
     """A planned action for an appliance."""
+
     appliance_id: str
     action: Action
     target_current: float | None
@@ -207,6 +228,7 @@ class PlanEntry:
 @dataclass
 class Plan:
     """Output of the planner - schedule for the next hours."""
+
     created_at: datetime
     horizon: timedelta
     entries: list[PlanEntry]
@@ -217,6 +239,7 @@ class Plan:
 @dataclass(frozen=True)
 class ControlDecision:
     """Output of the optimizer for a single appliance."""
+
     appliance_id: str
     action: Action
     target_current: float | None
@@ -228,6 +251,7 @@ class ControlDecision:
 @dataclass(frozen=True)
 class BatteryDischargeAction:
     """Battery discharge limit decision."""
+
     should_limit: bool
     max_discharge_watts: float | None = None
 
@@ -235,6 +259,7 @@ class BatteryDischargeAction:
 @dataclass
 class OptimizerResult:
     """Complete output of the optimizer for a single cycle."""
+
     decisions: list[ControlDecision]
     battery_discharge_action: BatteryDischargeAction
 
@@ -248,6 +273,7 @@ class InverterGridChargeConfig:
     - Two-step: select-mode + select-command (mode_entity_id + enable_entity_id, no power).
     - Three-step (e.g. Sungrow mkaiser): select-mode + select-command + number-power.
     """
+
     enable_entity_id: str
     enable_engage_value: str
     enable_disengage_value: str

--- a/custom_components/pv_excess_control/notifications.py
+++ b/custom_components/pv_excess_control/notifications.py
@@ -1,4 +1,5 @@
 """Notification manager for PV Excess Control."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -22,7 +23,11 @@ class NotificationManager:
         notification_service: str | None = None,
     ) -> None:
         self.hass = hass
-        self.settings = notification_settings if notification_settings is not None else DEFAULT_NOTIFICATION_SETTINGS.copy()
+        self.settings = (
+            notification_settings
+            if notification_settings is not None
+            else DEFAULT_NOTIFICATION_SETTINGS.copy()
+        )
         self.service = notification_service  # e.g., "notify.mobile_app_phone"
         self._last_sent: dict[str, datetime] = {}
         self._rate_limit_seconds = 300  # 5 minutes
@@ -44,7 +49,10 @@ class NotificationManager:
 
         if self.service:
             if "." not in self.service:
-                _LOGGER.warning("Invalid notification service format: %s (expected domain.service)", self.service)
+                _LOGGER.warning(
+                    "Invalid notification service format: %s (expected domain.service)",
+                    self.service,
+                )
                 return False
             domain, service_name = self.service.split(".", 1)
             await self.hass.services.async_call(

--- a/custom_components/pv_excess_control/number.py
+++ b/custom_components/pv_excess_control/number.py
@@ -1,4 +1,5 @@
 """Number platform for PV Excess Control."""
+
 from __future__ import annotations
 
 import logging
@@ -37,10 +38,18 @@ async def async_setup_entry(
     # Per-appliance number entities: priority, min/max daily runtime
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
-        appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(AppliancePriorityNumber(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceMinDailyRuntimeNumber(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceMaxDailyRuntimeNumber(coordinator, subentry_id, appliance_name))
+        appliance_name = subentry.data.get(
+            CONF_APPLIANCE_NAME, f"Appliance {subentry_id}"
+        )
+        entities.append(
+            AppliancePriorityNumber(coordinator, subentry_id, appliance_name)
+        )
+        entities.append(
+            ApplianceMinDailyRuntimeNumber(coordinator, subentry_id, appliance_name)
+        )
+        entities.append(
+            ApplianceMaxDailyRuntimeNumber(coordinator, subentry_id, appliance_name)
+        )
 
     async_add_entities(entities)
 
@@ -79,9 +88,7 @@ class AppliancePriorityNumber(CoordinatorEntity[PvExcessCoordinator], NumberEnti
 
     @property
     def native_value(self) -> float:
-        return float(
-            self.coordinator.appliance_priorities.get(self._appliance_id, 500)
-        )
+        return float(self.coordinator.appliance_priorities.get(self._appliance_id, 500))
 
     async def async_set_native_value(self, value: float) -> None:
         self.coordinator.appliance_priorities[self._appliance_id] = int(value)
@@ -98,11 +105,16 @@ class AppliancePriorityNumber(CoordinatorEntity[PvExcessCoordinator], NumberEnti
         except Exception:
             # async_update_subentry may not exist in older HA versions;
             # runtime override still works until restart
-            _LOGGER.debug("Could not persist priority for %s (HA version may not support subentry updates)", self._appliance_id)
+            _LOGGER.debug(
+                "Could not persist priority for %s (HA version may not support subentry updates)",
+                self._appliance_id,
+            )
         self.async_write_ha_state()
 
 
-class ApplianceMinDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], NumberEntity):
+class ApplianceMinDailyRuntimeNumber(
+    CoordinatorEntity[PvExcessCoordinator], NumberEntity
+):
     """Per-appliance minimum daily runtime (minutes).
 
     0 means "disabled" (no minimum). Writes persist to the subentry so
@@ -188,7 +200,9 @@ class ApplianceMinDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], Num
             )
 
 
-class ApplianceMaxDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], NumberEntity):
+class ApplianceMaxDailyRuntimeNumber(
+    CoordinatorEntity[PvExcessCoordinator], NumberEntity
+):
     """Per-appliance maximum daily runtime (minutes).
 
     0 means "disabled" (no maximum). Writes persist to the subentry so
@@ -240,7 +254,9 @@ class ApplianceMaxDailyRuntimeNumber(CoordinatorEntity[PvExcessCoordinator], Num
             min_effective = self._effective_min()
             if min_effective is not None and new_value < min_effective:
                 # Lower the sibling (min) to match the new max before writing self.
-                self.coordinator.appliance_min_daily_runtime[self._appliance_id] = new_value
+                self.coordinator.appliance_min_daily_runtime[self._appliance_id] = (
+                    new_value
+                )
                 await self._persist_min_to_subentry(new_value)
         self.coordinator.appliance_max_daily_runtime[self._appliance_id] = new_value
         await self._persist_to_subentry(new_value)

--- a/custom_components/pv_excess_control/optimizer.py
+++ b/custom_components/pv_excess_control/optimizer.py
@@ -464,14 +464,13 @@ class Optimizer:
                     # reported as disconnected. No vehicle means no additional
                     # load can actually be created by this decision.
                     ev_explicitly_disconnected = (
-                        appliance.ev_connected_entity
-                        and state.ev_connected is False
+                        appliance.ev_connected_entity and state.ev_connected is False
                     )
                     power_consumed = (
                         0.0
                         if ev_explicitly_disconnected
                         else appliance.max_current * self.grid_voltage * phases
-                    )                  
+                    )
                 return (
                     ControlDecision(
                         appliance_id=appliance.id,

--- a/custom_components/pv_excess_control/optimizer.py
+++ b/custom_components/pv_excess_control/optimizer.py
@@ -16,6 +16,7 @@ from datetime import time
 from zoneinfo import ZoneInfo
 
 from custom_components.pv_excess_control.const import (
+    DEFAULT_CONTROLLER_INTERVAL,
     DEFAULT_DYNAMIC_ON_THRESHOLD,
     DEFAULT_GRID_VOLTAGE,
     DEFAULT_OFF_THRESHOLD,
@@ -57,12 +58,14 @@ class Optimizer:
         enable_preemption: bool = True,
         off_threshold: int = DEFAULT_OFF_THRESHOLD,
         min_good_samples: int = 3,
+        controller_interval: int = DEFAULT_CONTROLLER_INTERVAL,
     ) -> None:
         self.grid_voltage = grid_voltage
         self._tz = ZoneInfo(timezone_str) if timezone_str else None
         self.enable_preemption = enable_preemption
         self._off_threshold = off_threshold
         self._min_good_samples = min_good_samples
+        self._controller_interval = max(1, controller_interval)
         # Initialised here for safety; optimize() overwrites both on every cycle.
         self._plan_influence: str = "none"
         self._grid_supplement_count: int = 0
@@ -151,11 +154,13 @@ class Optimizer:
         # avg_budget fallback (the same branch as appliances with no
         # custom window).
         self._appliance_avg_excess: dict[str, float] = {}
-        controller_interval = 30  # default, used for window→entry count conversion
         for app in appliances:
             if app.averaging_window is not None and app.averaging_window > 0:
                 # Calculate how many history entries fit in the custom window
-                entries_needed = max(1, int(app.averaging_window / controller_interval))
+                entries_needed = max(
+                    1,
+                    math.ceil(app.averaging_window / self._controller_interval),
+                )
                 recent = (
                     power_history[-entries_needed:]
                     if len(power_history) >= entries_needed

--- a/custom_components/pv_excess_control/optimizer.py
+++ b/custom_components/pv_excess_control/optimizer.py
@@ -7,6 +7,7 @@ Runs 5 phases per cycle:
   Phase 3:   SHED - Reduce/turn off lowest-priority appliances when excess is negative
   Phase 4:   BATTERY DISCHARGE PROTECTION - Limit battery discharge for big consumers
 """
+
 from __future__ import annotations
 
 import logging
@@ -113,7 +114,9 @@ class Optimizer:
             "Optimizer start: %d appliances, avg_excess=%s, current_excess=%s",
             len(appliances),
             f"{avg_excess:.0f}W" if avg_excess is not None else "unavailable",
-            f"{power_state.excess_power:.0f}W" if power_state.excess_power is not None else "unavailable",
+            f"{power_state.excess_power:.0f}W"
+            if power_state.excess_power is not None
+            else "unavailable",
         )
 
         # Sort appliances by (helper_only, priority, id):
@@ -125,7 +128,9 @@ class Optimizer:
         # evaluate AFTER their dependents so the helper-only short-circuit
         # in _apply_safety_rules can find dependent decisions in the
         # in-progress decisions list.
-        sorted_appliances = sorted(appliances, key=lambda a: (a.helper_only, a.priority, a.id))
+        sorted_appliances = sorted(
+            appliances, key=lambda a: (a.helper_only, a.priority, a.id)
+        )
 
         # If ASSESS produced no trustworthy excess, take the safety-only
         # path: run safety checks and Phase 4, skip Phases 2/2.5/3.
@@ -151,7 +156,11 @@ class Optimizer:
             if app.averaging_window is not None and app.averaging_window > 0:
                 # Calculate how many history entries fit in the custom window
                 entries_needed = max(1, int(app.averaging_window / controller_interval))
-                recent = power_history[-entries_needed:] if len(power_history) >= entries_needed else power_history
+                recent = (
+                    power_history[-entries_needed:]
+                    if len(power_history) >= entries_needed
+                    else power_history
+                )
                 per_app_avg = self._calculate_average_excess(recent)
                 if per_app_avg is not None:
                     self._appliance_avg_excess[app.id] = per_app_avg
@@ -177,31 +186,45 @@ class Optimizer:
             state = state_by_id.get(appliance.id)
             if state is None:
                 # No state found for this appliance - skip with IDLE
-                decisions.append(ControlDecision(
-                    appliance_id=appliance.id,
-                    action=Action.IDLE,
-                    target_current=None,
-                    reason="No state data available",
-                    overrides_plan=False,
-                ))
+                decisions.append(
+                    ControlDecision(
+                        appliance_id=appliance.id,
+                        action=Action.IDLE,
+                        target_current=None,
+                        reason="No state data available",
+                        overrides_plan=False,
+                    )
+                )
                 continue
 
             # Use per-appliance averaged excess if configured, adjusted by prior consumption
             if appliance.id in self._appliance_avg_excess:
-                app_avg_budget = self._appliance_avg_excess[appliance.id] - total_consumed
+                app_avg_budget = (
+                    self._appliance_avg_excess[appliance.id] - total_consumed
+                )
             else:
                 app_avg_budget = avg_budget
 
             decision, power_consumed = self._allocate_appliance(
-                appliance, state, app_avg_budget, instant_budget, plan, tariff,
+                appliance,
+                state,
+                app_avg_budget,
+                instant_budget,
+                plan,
+                tariff,
                 decisions=decisions,
                 state_by_id=state_by_id,
             )
             decisions.append(decision)
             _LOGGER.debug(
                 "  Allocate %s (p=%d, %sW): avg=%.0fW inst=%.0fW -> %s (%s)",
-                appliance.name, appliance.priority, appliance.nominal_power,
-                avg_budget, instant_budget, decision.action, decision.reason,
+                appliance.name,
+                appliance.priority,
+                appliance.nominal_power,
+                avg_budget,
+                instant_budget,
+                decision.action,
+                decision.reason,
             )
             avg_budget -= power_consumed
             instant_budget -= power_consumed
@@ -220,19 +243,26 @@ class Optimizer:
         # threaded through and returned.
         if self.enable_preemption:
             avg_budget, instant_budget = self._preempt(
-                decisions, sorted_appliances, state_by_id,
-                avg_budget, instant_budget,
+                decisions,
+                sorted_appliances,
+                state_by_id,
+                avg_budget,
+                instant_budget,
             )
 
         # Phase 3: SHED — reads the instantaneous budget (physical reality).
         instant_budget = self._shed(
-            decisions, sorted_appliances, state_by_id, instant_budget,
+            decisions,
+            sorted_appliances,
+            state_by_id,
+            instant_budget,
             force_shed=force_charge,
         )
 
         # Phase 4: BATTERY DISCHARGE PROTECTION
         battery_action = self._battery_discharge_protection(
-            decisions, sorted_appliances,
+            decisions,
+            sorted_appliances,
             battery_soc=power_state.battery_soc,
             min_battery_soc=min_battery_soc,
             force_charge=force_charge,
@@ -244,7 +274,9 @@ class Optimizer:
             battery_discharge_action=battery_action,
         )
 
-    def _calculate_average_excess(self, power_history: list[PowerState]) -> float | None:
+    def _calculate_average_excess(
+        self, power_history: list[PowerState]
+    ) -> float | None:
         """Calculate the average excess power from the history window.
 
         Returns ``None`` when fewer than ``self._min_good_samples``
@@ -269,25 +301,33 @@ class Optimizer:
     def _plan_says_on(self, appliance_id: str, plan: Plan) -> bool:
         """Check if the plan has an ON entry for this appliance in the current time window."""
         from datetime import datetime
+
         # Use HA timezone if configured, otherwise fall back to system local timezone.
         now = datetime.now(self._tz) if self._tz else datetime.now().astimezone()
         for entry in plan.entries:
             if entry.appliance_id != appliance_id:
                 continue
-            if entry.action in (Action.ON, Action.SET_CURRENT):
-                if entry.window:
-                    window_start = entry.window.start
-                    window_end = entry.window.end
-                    try:
-                        if window_start <= now <= window_end:
-                            return True
-                    except TypeError:
-                        # Mixed naive/aware — compare as naive
-                        now_naive = now.replace(tzinfo=None)
-                        start_naive = window_start.replace(tzinfo=None) if window_start.tzinfo else window_start
-                        end_naive = window_end.replace(tzinfo=None) if window_end.tzinfo else window_end
-                        if start_naive <= now_naive <= end_naive:
-                            return True
+            if entry.action in (Action.ON, Action.SET_CURRENT) and entry.window:
+                window_start = entry.window.start
+                window_end = entry.window.end
+                try:
+                    if window_start <= now <= window_end:
+                        return True
+                except TypeError:
+                    # Mixed naive/aware — compare as naive
+                    now_naive = now.replace(tzinfo=None)
+                    start_naive = (
+                        window_start.replace(tzinfo=None)
+                        if window_start.tzinfo
+                        else window_start
+                    )
+                    end_naive = (
+                        window_end.replace(tzinfo=None)
+                        if window_end.tzinfo
+                        else window_end
+                    )
+                    if start_naive <= now_naive <= end_naive:
+                        return True
         return False
 
     def _has_running_dependent(
@@ -361,9 +401,13 @@ class Optimizer:
             and state.runtime_today >= appliance.max_daily_runtime
         ):
             if appliance.on_only:
-                _LOGGER.info("Max daily runtime overrides on_only for %s", appliance.name)
+                _LOGGER.info(
+                    "Max daily runtime overrides on_only for %s", appliance.name
+                )
             if appliance.override_active:
-                _LOGGER.info("Max daily runtime overrides manual override for %s", appliance.name)
+                _LOGGER.info(
+                    "Max daily runtime overrides manual override for %s", appliance.name
+                )
             return (
                 ControlDecision(
                     appliance_id=appliance.id,
@@ -403,8 +447,13 @@ class Optimizer:
                 if state.is_on:
                     if state.current_power > 0:
                         current_power = state.current_power
-                    elif state.current_amperage is not None and state.current_amperage > 0:
-                        current_power = state.current_amperage * self.grid_voltage * phases
+                    elif (
+                        state.current_amperage is not None
+                        and state.current_amperage > 0
+                    ):
+                        current_power = (
+                            state.current_amperage * self.grid_voltage * phases
+                        )
                     else:
                         current_power = appliance.nominal_power
                     target_power = appliance.max_current * self.grid_voltage * phases
@@ -474,9 +523,8 @@ class Optimizer:
                     appliance_id=appliance.id,
                     action=action,
                     target_current=None,
-                    reason="EV not confirmed connected (sensor: %s)" % (
-                        "unavailable" if state.ev_connected is None else "disconnected"
-                    ),
+                    reason="EV not confirmed connected (sensor: %s)"
+                    % ("unavailable" if state.ev_connected is None else "disconnected"),
                     overrides_plan=False,
                     bypasses_cooldown=True,
                 ),
@@ -485,9 +533,11 @@ class Optimizer:
 
         # EV SoC target check: stop charging when target reached
         # Placed before on_only so that EV SoC target is respected even for on_only appliances
-        if (appliance.ev_target_soc is not None
-                and state.ev_soc is not None
-                and state.ev_soc >= appliance.ev_target_soc):
+        if (
+            appliance.ev_target_soc is not None
+            and state.ev_soc is not None
+            and state.ev_soc >= appliance.ev_target_soc
+        ):
             action = Action.OFF if state.is_on else Action.IDLE
             return (
                 ControlDecision(
@@ -528,7 +578,9 @@ class Optimizer:
                 action = Action.OFF if state.is_on else Action.IDLE
                 return (
                     ControlDecision(
-                        appliance_id=appliance.id, action=action, target_current=None,
+                        appliance_id=appliance.id,
+                        action=action,
+                        target_current=None,
                         reason=f"Dependency '{appliance.requires_appliance}' unavailable (disabled or removed)",
                         overrides_plan=False,
                     ),
@@ -538,15 +590,24 @@ class Optimizer:
         # Time window check: restrict appliance to specific operating hours
         if appliance.start_after is not None or appliance.end_before is not None:
             from datetime import datetime
-            current_time = datetime.now(self._tz).time() if self._tz else datetime.now().time()
-            if not self._is_within_time_window(current_time, appliance.start_after, appliance.end_before):
+
+            current_time = (
+                datetime.now(self._tz).time() if self._tz else datetime.now().time()
+            )
+            if not self._is_within_time_window(
+                current_time, appliance.start_after, appliance.end_before
+            ):
                 action = Action.OFF if state.is_on else Action.IDLE
                 # Build a descriptive reason
                 window_parts: list[str] = []
                 if appliance.start_after is not None:
-                    window_parts.append(f"after {appliance.start_after.strftime('%H:%M')}")
+                    window_parts.append(
+                        f"after {appliance.start_after.strftime('%H:%M')}"
+                    )
                 if appliance.end_before is not None:
-                    window_parts.append(f"before {appliance.end_before.strftime('%H:%M')}")
+                    window_parts.append(
+                        f"before {appliance.end_before.strftime('%H:%M')}"
+                    )
                 window_desc = " and ".join(window_parts)
                 return (
                     ControlDecision(
@@ -588,16 +649,19 @@ class Optimizer:
         for appliance in sorted_appliances:
             state = state_by_id.get(appliance.id)
             if state is None:
-                decisions.append(ControlDecision(
-                    appliance_id=appliance.id,
-                    action=Action.IDLE,
-                    target_current=None,
-                    reason="No state data available",
-                    overrides_plan=False,
-                ))
+                decisions.append(
+                    ControlDecision(
+                        appliance_id=appliance.id,
+                        action=Action.IDLE,
+                        target_current=None,
+                        reason="No state data available",
+                        overrides_plan=False,
+                    )
+                )
                 continue
             safety_result = self._apply_safety_rules(
-                appliance, state,
+                appliance,
+                state,
                 decisions=decisions,
                 state_by_id=state_by_id,
             )
@@ -608,16 +672,19 @@ class Optimizer:
                 # Emit a hold-ON decision so Phase 4 can see this big consumer
                 # and apply battery discharge limits. Without a decision entry
                 # _battery_discharge_protection would not detect it as active.
-                decisions.append(ControlDecision(
-                    appliance_id=appliance.id,
-                    action=Action.ON,
-                    target_current=None,
-                    reason="Excess unavailable - holding state",
-                    overrides_plan=False,
-                ))
+                decisions.append(
+                    ControlDecision(
+                        appliance_id=appliance.id,
+                        action=Action.ON,
+                        target_current=None,
+                        reason="Excess unavailable - holding state",
+                        overrides_plan=False,
+                    )
+                )
 
         battery_action = self._battery_discharge_protection(
-            decisions, sorted_appliances,
+            decisions,
+            sorted_appliances,
             battery_soc=power_state.battery_soc,
             min_battery_soc=min_battery_soc,
             force_charge=force_charge,
@@ -626,7 +693,8 @@ class Optimizer:
 
         _LOGGER.info(
             "Optimizer safety-only path: %d decisions, battery_action=%s",
-            len(decisions), battery_action,
+            len(decisions),
+            battery_action,
         )
         return OptimizerResult(
             decisions=decisions,
@@ -668,7 +736,8 @@ class Optimizer:
         # so the safety-only optimizer path (triggered when ASSESS returns
         # None) can reuse them.
         safety_result = self._apply_safety_rules(
-            appliance, state,
+            appliance,
+            state,
             decisions=decisions if decisions is not None else [],
             state_by_id=state_by_id if state_by_id is not None else {},
         )
@@ -709,10 +778,11 @@ class Optimizer:
                 # early-return so a configured override keeps the appliance
                 # running through transient negative-budget cycles instead of
                 # falling back to a SHED-eligible "staying on" decision.
-                override_amps = self._cheap_window_target_amps(appliance, tariff, phases)
-                override_active = (
-                    override_amps is not None
-                    and override_amps > max(target_amps, appliance.min_current)
+                override_amps = self._cheap_window_target_amps(
+                    appliance, tariff, phases
+                )
+                override_active = override_amps is not None and override_amps > max(
+                    target_amps, appliance.min_current
                 )
 
                 if target_amps < appliance.min_current and not override_active:
@@ -734,7 +804,9 @@ class Optimizer:
                         0.0,
                     )
 
-                target_amps = max(appliance.min_current, min(target_amps, appliance.max_current))
+                target_amps = max(
+                    appliance.min_current, min(target_amps, appliance.max_current)
+                )
                 if override_active:
                     target_amps = override_amps  # already capped by helper
                 power_at_target = target_amps * self.grid_voltage * phases
@@ -808,8 +880,14 @@ class Optimizer:
                 # override target instead of min_current. Otherwise default to
                 # min_current as before.
                 phases = max(appliance.phases, 1)
-                override_amps = self._cheap_window_target_amps(appliance, tariff, phases)
-                target_amps = override_amps if override_amps is not None else appliance.min_current
+                override_amps = self._cheap_window_target_amps(
+                    appliance, tariff, phases
+                )
+                target_amps = (
+                    override_amps
+                    if override_amps is not None
+                    else appliance.min_current
+                )
                 return (
                     ControlDecision(
                         appliance_id=appliance.id,
@@ -840,12 +918,20 @@ class Optimizer:
         # --- Dynamic current appliances (currently OFF) ---
         if appliance.dynamic_current:
             return self._allocate_dynamic_current(
-                appliance, state, avg_budget, tariff, plan,
+                appliance,
+                state,
+                avg_budget,
+                tariff,
+                plan,
             )
 
         # --- Standard (on/off) appliances (currently OFF) ---
         return self._allocate_standard(
-            appliance, state, avg_budget, tariff, plan,
+            appliance,
+            state,
+            avg_budget,
+            tariff,
+            plan,
         )
 
     def _allocate_standard(
@@ -887,7 +973,11 @@ class Optimizer:
             threshold = max(appliance.nominal_power * 0.1, 50.0)
         else:
             # Normal threshold
-            on_buf = appliance.on_threshold if appliance.on_threshold is not None else DEFAULT_ON_THRESHOLD
+            on_buf = (
+                appliance.on_threshold
+                if appliance.on_threshold is not None
+                else DEFAULT_ON_THRESHOLD
+            )
             threshold = appliance.nominal_power + on_buf
 
         # Appliance is currently OFF - use computed threshold (plus dependency power if needed)
@@ -902,11 +992,14 @@ class Optimizer:
                 power_consumed = appliance.nominal_power
             # If dependency is OFF, inject a pending decision to turn it ON
             if dep_power > 0:
-                self._pending_dep_decisions[appliance.requires_appliance] = ControlDecision(
-                    appliance_id=appliance.requires_appliance, action=Action.ON,
-                    target_current=None,
-                    reason=f"Started as dependency for {appliance.name}",
-                    overrides_plan=False,
+                self._pending_dep_decisions[appliance.requires_appliance] = (
+                    ControlDecision(
+                        appliance_id=appliance.requires_appliance,
+                        action=Action.ON,
+                        target_current=None,
+                        reason=f"Started as dependency for {appliance.name}",
+                        overrides_plan=False,
+                    )
                 )
                 power_consumed = power_consumed + dep_power
             return (
@@ -924,25 +1017,35 @@ class Optimizer:
         # If not enough excess but tariff is cheap, allow grid to fill the gap.
         # Only deduct the solar portion from the excess budget; the grid portion
         # is intentionally imported and should not make avg_budget negative.
-        if (
-            appliance.allow_grid_supplement
-            and self._is_cheap_for_appliance(tariff, appliance)
+        if appliance.allow_grid_supplement and self._is_cheap_for_appliance(
+            tariff, appliance
         ):
-            max_grid = appliance.max_grid_power if appliance.max_grid_power is not None else appliance.nominal_power
+            max_grid = (
+                appliance.max_grid_power
+                if appliance.max_grid_power is not None
+                else appliance.nominal_power
+            )
             solar_portion = max(avg_budget, 0.0)
             grid_supplement_needed = appliance.nominal_power - solar_portion
             if grid_supplement_needed <= max_grid:
                 # If dependency is OFF, inject a pending decision to turn it ON
                 grid_power_consumed = solar_portion
                 if dep_power > 0:
-                    self._pending_dep_decisions[appliance.requires_appliance] = ControlDecision(
-                        appliance_id=appliance.requires_appliance, action=Action.ON,
-                        target_current=None,
-                        reason=f"Started as dependency for {appliance.name}",
-                        overrides_plan=False,
+                    self._pending_dep_decisions[appliance.requires_appliance] = (
+                        ControlDecision(
+                            appliance_id=appliance.requires_appliance,
+                            action=Action.ON,
+                            target_current=None,
+                            reason=f"Started as dependency for {appliance.name}",
+                            overrides_plan=False,
+                        )
                     )
                     grid_power_consumed = solar_portion + dep_power
-                effective_threshold = appliance.cheap_price_threshold if appliance.cheap_price_threshold is not None else tariff.cheap_price_threshold
+                effective_threshold = (
+                    appliance.cheap_price_threshold
+                    if appliance.cheap_price_threshold is not None
+                    else tariff.cheap_price_threshold
+                )
                 return (
                     ControlDecision(
                         appliance_id=appliance.id,
@@ -965,12 +1068,21 @@ class Optimizer:
             and state.runtime_today < appliance.min_daily_runtime
         ):
             from datetime import datetime
-            current_time = datetime.now(self._tz).time() if self._tz else datetime.now().time()
+
+            current_time = (
+                datetime.now(self._tz).time() if self._tz else datetime.now().time()
+            )
             deadline = appliance.schedule_deadline
-            remaining_runtime = (appliance.min_daily_runtime - state.runtime_today).total_seconds()
+            remaining_runtime = (
+                appliance.min_daily_runtime - state.runtime_today
+            ).total_seconds()
 
             # Calculate time until deadline
-            now_seconds = current_time.hour * 3600 + current_time.minute * 60 + current_time.second
+            now_seconds = (
+                current_time.hour * 3600
+                + current_time.minute * 60
+                + current_time.second
+            )
             deadline_seconds = deadline.hour * 3600 + deadline.minute * 60
             is_overnight = deadline_seconds <= now_seconds
             if is_overnight:
@@ -1043,21 +1155,36 @@ class Optimizer:
             # Plan says ON: allow activation at minimum current with no buffer
             dynamic_buffer = 0.0
         else:
-            dynamic_buffer = appliance.on_threshold if appliance.on_threshold is not None else DEFAULT_DYNAMIC_ON_THRESHOLD
+            dynamic_buffer = (
+                appliance.on_threshold
+                if appliance.on_threshold is not None
+                else DEFAULT_DYNAMIC_ON_THRESHOLD
+            )
 
-        min_watts_needed = appliance.min_current * self.grid_voltage * phases + dynamic_buffer
+        min_watts_needed = (
+            appliance.min_current * self.grid_voltage * phases + dynamic_buffer
+        )
 
         if avg_budget < min_watts_needed:
             # Not enough excess — try grid supplementation if tariff is cheap
-            if (
-                appliance.allow_grid_supplement
-                and self._is_cheap_for_appliance(tariff, appliance)
+            if appliance.allow_grid_supplement and self._is_cheap_for_appliance(
+                tariff, appliance
             ):
-                override_amps = self._cheap_window_target_amps(appliance, tariff, phases)
-                target_amps = override_amps if override_amps is not None else appliance.min_current
+                override_amps = self._cheap_window_target_amps(
+                    appliance, tariff, phases
+                )
+                target_amps = (
+                    override_amps
+                    if override_amps is not None
+                    else appliance.min_current
+                )
                 target_power = target_amps * self.grid_voltage * phases
                 solar_portion = max(avg_budget, 0.0)
-                effective_threshold = appliance.cheap_price_threshold if appliance.cheap_price_threshold is not None else tariff.cheap_price_threshold
+                effective_threshold = (
+                    appliance.cheap_price_threshold
+                    if appliance.cheap_price_threshold is not None
+                    else tariff.cheap_price_threshold
+                )
                 if override_amps is not None:
                     reason = (
                         f"Grid supplement (cheap-window target): {target_amps:.1f}A "
@@ -1088,10 +1215,19 @@ class Optimizer:
                 and state.runtime_today < appliance.min_daily_runtime
             ):
                 from datetime import datetime
-                current_time = datetime.now(self._tz).time() if self._tz else datetime.now().time()
+
+                current_time = (
+                    datetime.now(self._tz).time() if self._tz else datetime.now().time()
+                )
                 deadline = appliance.schedule_deadline
-                remaining_runtime = (appliance.min_daily_runtime - state.runtime_today).total_seconds()
-                now_seconds = current_time.hour * 3600 + current_time.minute * 60 + current_time.second
+                remaining_runtime = (
+                    appliance.min_daily_runtime - state.runtime_today
+                ).total_seconds()
+                now_seconds = (
+                    current_time.hour * 3600
+                    + current_time.minute * 60
+                    + current_time.second
+                )
                 deadline_seconds = deadline.hour * 3600 + deadline.minute * 60
                 is_overnight = deadline_seconds <= now_seconds
                 if is_overnight:
@@ -1138,10 +1274,14 @@ class Optimizer:
         raw_amps = avg_budget / (self.grid_voltage * phases)
         clamped_amps = _step_floor(raw_amps, appliance.current_step)
 
-        natural_target_amps = max(appliance.min_current, min(clamped_amps, appliance.max_current))
+        natural_target_amps = max(
+            appliance.min_current, min(clamped_amps, appliance.max_current)
+        )
 
         override_amps = self._cheap_window_target_amps(appliance, tariff, phases)
-        override_active = override_amps is not None and override_amps > natural_target_amps
+        override_active = (
+            override_amps is not None and override_amps > natural_target_amps
+        )
         target_amps = override_amps if override_active else natural_target_amps
 
         power_consumed = target_amps * self.grid_voltage * phases
@@ -1225,7 +1365,9 @@ class Optimizer:
 
         cap_amps = appliance.max_current
         if appliance.max_grid_power is not None:
-            cap_amps = min(cap_amps, appliance.max_grid_power / (self.grid_voltage * phases))
+            cap_amps = min(
+                cap_amps, appliance.max_grid_power / (self.grid_voltage * phases)
+            )
 
         target_amps = max(appliance.cheap_grid_target_current, appliance.min_current)
         target_amps = min(target_amps, cap_amps)
@@ -1318,13 +1460,20 @@ class Optimizer:
             # Calculate power_needed to start this appliance
             if idle_app.dynamic_current and idle_app.current_entity:
                 phases = max(idle_app.phases, 1)
-                dyn_buf = idle_app.on_threshold if idle_app.on_threshold is not None else DEFAULT_DYNAMIC_ON_THRESHOLD
+                dyn_buf = (
+                    idle_app.on_threshold
+                    if idle_app.on_threshold is not None
+                    else DEFAULT_DYNAMIC_ON_THRESHOLD
+                )
                 power_needed = (
-                    idle_app.min_current * self.grid_voltage * phases
-                    + dyn_buf
+                    idle_app.min_current * self.grid_voltage * phases + dyn_buf
                 )
             else:
-                on_buf = idle_app.on_threshold if idle_app.on_threshold is not None else DEFAULT_ON_THRESHOLD
+                on_buf = (
+                    idle_app.on_threshold
+                    if idle_app.on_threshold is not None
+                    else DEFAULT_ON_THRESHOLD
+                )
                 power_needed = idle_app.nominal_power + on_buf
 
             # Add dependency power if dependency is OFF
@@ -1344,8 +1493,8 @@ class Optimizer:
 
             power_needed += dep_power
 
-            # Collect preemptable ON/SET_CURRENT decisions for lower-priority appliances
-            preemptable: list[tuple[str, ApplianceConfig, float]] = []
+            # Collect preemptible ON/SET_CURRENT decisions for lower-priority appliances
+            preemptible: list[tuple[str, ApplianceConfig, float]] = []
             for decision in decisions:
                 if decision.action not in (Action.ON, Action.SET_CURRENT):
                     continue
@@ -1356,7 +1505,10 @@ class Optimizer:
                 if app.priority <= idle_app.priority:
                     continue
                 # Never preempt the idle candidate's own dependency
-                if idle_app.requires_appliance and app.id == idle_app.requires_appliance:
+                if (
+                    idle_app.requires_appliance
+                    and app.id == idle_app.requires_appliance
+                ):
                     continue
                 # Never preempt on_only
                 if app.on_only:
@@ -1394,16 +1546,16 @@ class Optimizer:
                     if state and state.current_power > 0
                     else app.nominal_power
                 )
-                preemptable.append((app.id, app, freed))
+                preemptible.append((app.id, app, freed))
 
-            # Sort preemptable: highest priority number first (least important first)
-            preemptable.sort(key=lambda item: (-item[1].priority, item[0]))
+            # Sort preemptible: highest priority number first (least important first)
+            preemptible.sort(key=lambda item: (-item[1].priority, item[0]))
 
             # Accumulate freed power until we have enough.
             # Feasibility check uses avg_budget (the conservative turn-on view).
             total_freed = 0.0
             to_preempt: list[tuple[str, ApplianceConfig, float]] = []
-            for p_id, p_app, freed in preemptable:
+            for p_id, p_app, freed in preemptible:
                 to_preempt.append((p_id, p_app, freed))
                 total_freed += freed
                 if avg_budget + total_freed >= power_needed:
@@ -1428,8 +1580,11 @@ class Optimizer:
                 instant_budget += freed
                 _LOGGER.debug(
                     "  Preempt %s (p=%d): freed %.0fW for %s (p=%d)",
-                    p_app.name, p_app.priority, freed,
-                    idle_app.name, idle_app.priority,
+                    p_app.name,
+                    p_app.priority,
+                    freed,
+                    idle_app.name,
+                    idle_app.priority,
                 )
 
             # Replace idle decision with ON or SET_CURRENT. Target_amps is
@@ -1457,7 +1612,7 @@ class Optimizer:
                     appliance_id=idle_id,
                     action=Action.ON,
                     target_current=None,
-                    reason=f"Preemption: started after shedding lower-priority appliances",
+                    reason="Preemption: started after shedding lower-priority appliances",
                     overrides_plan=False,
                 )
             avg_budget -= power_consumed
@@ -1478,7 +1633,9 @@ class Optimizer:
 
             _LOGGER.debug(
                 "  Preempt result: %s ON, avg=%.0fW inst=%.0fW",
-                idle_app.name, avg_budget, instant_budget,
+                idle_app.name,
+                avg_budget,
+                instant_budget,
             )
 
         return avg_budget, instant_budget
@@ -1585,13 +1742,17 @@ class Optimizer:
             # Hard min_runtime constraint: don't shed if minimum not met
             # (bypassed during force_charge to prioritise battery charging)
             state = state_by_id.get(app_id)
-            if (not force_shed
-                    and appliance.min_daily_runtime is not None
-                    and state is not None
-                    and state.runtime_today < appliance.min_daily_runtime):
+            if (
+                not force_shed
+                and appliance.min_daily_runtime is not None
+                and state is not None
+                and state.runtime_today < appliance.min_daily_runtime
+            ):
                 _LOGGER.debug(
                     "  Skipping shed of %s: min_runtime not met (%s < %s)",
-                    appliance.name, state.runtime_today, appliance.min_daily_runtime,
+                    appliance.name,
+                    state.runtime_today,
+                    appliance.min_daily_runtime,
                 )
                 continue
 
@@ -1599,10 +1760,15 @@ class Optimizer:
             current_decision = decisions[idx]
 
             # For dynamic current appliances: try reducing current first
-            if appliance.dynamic_current and current_decision.action in (Action.ON, Action.SET_CURRENT):
+            if appliance.dynamic_current and current_decision.action in (
+                Action.ON,
+                Action.SET_CURRENT,
+            ):
                 state = state_by_id.get(app_id)
                 new_decision, power_freed = self._shed_dynamic_current(
-                    appliance, state, instant_budget,
+                    appliance,
+                    state,
+                    instant_budget,
                 )
                 if new_decision is not None:
                     decisions[idx] = new_decision
@@ -1611,8 +1777,11 @@ class Optimizer:
 
             # Turn off: free the appliance's actual consumption (or nominal as fallback)
             state = state_by_id.get(app_id)
-            freed_power = (state.current_power if state and state.current_power > 0
-                           else appliance.nominal_power)
+            freed_power = (
+                state.current_power
+                if state and state.current_power > 0
+                else appliance.nominal_power
+            )
             decisions[idx] = ControlDecision(
                 appliance_id=app_id,
                 action=Action.OFF,
@@ -1623,7 +1792,9 @@ class Optimizer:
             instant_budget += freed_power
             _LOGGER.debug(
                 "  Shed %s: freed %.0fW, inst=%.0fW",
-                appliance.name, freed_power, instant_budget,
+                appliance.name,
+                freed_power,
+                instant_budget,
             )
 
         return instant_budget
@@ -1648,7 +1819,11 @@ class Optimizer:
         # Current consumption: prefer measured power, then amperage-derived, then nominal
         if state is not None and state.current_power > 0:
             current_power = state.current_power
-        elif state is not None and state.current_amperage is not None and state.current_amperage > 0:
+        elif (
+            state is not None
+            and state.current_amperage is not None
+            and state.current_amperage > 0
+        ):
             current_power = state.current_amperage * self.grid_voltage * phases
         else:
             current_power = appliance.nominal_power
@@ -1710,9 +1885,7 @@ class Optimizer:
         SoC-based protection takes priority. Cheap-tariff overrules big-consumer
         because 0 is the most restrictive value.
         """
-        appliance_by_id: dict[str, ApplianceConfig] = {
-            a.id: a for a in appliances
-        }
+        appliance_by_id: dict[str, ApplianceConfig] = {a.id: a for a in appliances}
 
         # --- SoC-based protection ---
         if (
@@ -1723,7 +1896,8 @@ class Optimizer:
             _LOGGER.info(
                 "Battery SoC %.1f%% is below minimum %.1f%% — shedding appliances "
                 "and blocking discharge",
-                battery_soc, min_battery_soc,
+                battery_soc,
+                min_battery_soc,
             )
             # Shed all non-on_only, non-overridden appliances.
             # Shed big consumers first, then standard appliances.
@@ -1792,7 +1966,8 @@ class Optimizer:
         # any big-consumer override (since 0 is the smallest possible value).
         # Does NOT shed appliances — loads should run on cheap grid.
         grid_supplement_decisions = [
-            d for d in decisions
+            d
+            for d in decisions
             if d.action in (Action.ON, Action.SET_CURRENT)
             and "grid supplement" in d.reason.lower()
         ]
@@ -1851,7 +2026,8 @@ class Optimizer:
             ]
             _LOGGER.debug(
                 "  Battery protection: limiting discharge to %.0fW (active big consumers: %s)",
-                limit_watts, ", ".join(consumer_names),
+                limit_watts,
+                ", ".join(consumer_names),
             )
             return BatteryDischargeAction(
                 should_limit=True,

--- a/custom_components/pv_excess_control/optimizer.py
+++ b/custom_components/pv_excess_control/optimizer.py
@@ -459,7 +459,19 @@ class Optimizer:
                     target_power = appliance.max_current * self.grid_voltage * phases
                     power_consumed = max(target_power - current_power, 0.0)
                 else:
-                    power_consumed = appliance.max_current * self.grid_voltage * phases
+                    # Keep the manual override active and pre-set max current,
+                    # but do not reserve power when the EV is explicitly
+                    # reported as disconnected. No vehicle means no additional
+                    # load can actually be created by this decision.
+                    ev_explicitly_disconnected = (
+                        appliance.ev_connected_entity
+                        and state.ev_connected is False
+                    )
+                    power_consumed = (
+                        0.0
+                        if ev_explicitly_disconnected
+                        else appliance.max_current * self.grid_voltage * phases
+                    )                  
                 return (
                     ControlDecision(
                         appliance_id=appliance.id,

--- a/custom_components/pv_excess_control/planner.py
+++ b/custom_components/pv_excess_control/planner.py
@@ -6,10 +6,11 @@ pre-planning and export limit management, and outputs a complete Plan.
 
 Pure Python - no HA dependencies.
 """
+
 from __future__ import annotations
 
 import logging
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 from .models import (
@@ -49,7 +50,9 @@ class Planner:
         try:
             self.tz = ZoneInfo(timezone_str)
         except Exception:
-            _LOGGER.warning("Planner: unknown timezone %r, falling back to UTC", timezone_str)
+            _LOGGER.warning(
+                "Planner: unknown timezone %r, falling back to UTC", timezone_str
+            )
             self.tz = ZoneInfo("UTC")
 
     # ------------------------------------------------------------------
@@ -88,16 +91,18 @@ class Planner:
                 return []
             tariff_windows = []
             for hf in forecast.hourly_breakdown:
-                tariff_windows.append(TariffWindow(
-                    start=hf.start, end=hf.end,
-                    price=0.0, is_cheap=False,
-                ))
+                tariff_windows.append(
+                    TariffWindow(
+                        start=hf.start,
+                        end=hf.end,
+                        price=0.0,
+                        is_cheap=False,
+                    )
+                )
 
         # Sort tariff windows and forecasts chronologically
         sorted_tariffs = sorted(tariff_windows, key=lambda tw: tw.start)
-        sorted_forecasts = sorted(
-            forecast.hourly_breakdown, key=lambda hf: hf.start
-        )
+        sorted_forecasts = sorted(forecast.hourly_breakdown, key=lambda hf: hf.start)
 
         raw_slots: list[TimeSlot] = []
 
@@ -108,14 +113,16 @@ class Planner:
             if not overlapping:
                 # No forecast data for this window -> slot with 0 solar
                 excess = max(0.0 - base_load_watts, 0.0)
-                raw_slots.append(TimeSlot(
-                    start=tw.start,
-                    end=tw.end,
-                    expected_solar_watts=0.0,
-                    expected_excess_watts=excess,
-                    price=tw.price,
-                    is_cheap=tw.is_cheap,
-                ))
+                raw_slots.append(
+                    TimeSlot(
+                        start=tw.start,
+                        end=tw.end,
+                        expected_solar_watts=0.0,
+                        expected_excess_watts=excess,
+                        price=tw.price,
+                        is_cheap=tw.is_cheap,
+                    )
+                )
             else:
                 # Subdivide: create a sub-slot for each forecast entry
                 # that falls within this tariff window
@@ -128,14 +135,16 @@ class Planner:
                         continue
 
                     excess = max(fc.expected_watts - base_load_watts, 0.0)
-                    raw_slots.append(TimeSlot(
-                        start=slot_start,
-                        end=slot_end,
-                        expected_solar_watts=fc.expected_watts,
-                        expected_excess_watts=excess,
-                        price=tw.price,
-                        is_cheap=tw.is_cheap,
-                    ))
+                    raw_slots.append(
+                        TimeSlot(
+                            start=slot_start,
+                            end=slot_end,
+                            expected_solar_watts=fc.expected_watts,
+                            expected_excess_watts=excess,
+                            price=tw.price,
+                            is_cheap=tw.is_cheap,
+                        )
+                    )
 
         # Sort by start time
         raw_slots.sort(key=lambda s: s.start)
@@ -166,14 +175,16 @@ class Planner:
         if not slots:
             return []
 
-        merged: list[TimeSlot] = [TimeSlot(
-            start=slots[0].start,
-            end=slots[0].end,
-            expected_solar_watts=slots[0].expected_solar_watts,
-            expected_excess_watts=slots[0].expected_excess_watts,
-            price=slots[0].price,
-            is_cheap=slots[0].is_cheap,
-        )]
+        merged: list[TimeSlot] = [
+            TimeSlot(
+                start=slots[0].start,
+                end=slots[0].end,
+                expected_solar_watts=slots[0].expected_solar_watts,
+                expected_excess_watts=slots[0].expected_excess_watts,
+                price=slots[0].price,
+                is_cheap=slots[0].is_cheap,
+            )
+        ]
 
         for slot in slots[1:]:
             prev = merged[-1]
@@ -193,14 +204,16 @@ class Planner:
                     is_cheap=prev.is_cheap,
                 )
             else:
-                merged.append(TimeSlot(
-                    start=slot.start,
-                    end=slot.end,
-                    expected_solar_watts=slot.expected_solar_watts,
-                    expected_excess_watts=slot.expected_excess_watts,
-                    price=slot.price,
-                    is_cheap=slot.is_cheap,
-                ))
+                merged.append(
+                    TimeSlot(
+                        start=slot.start,
+                        end=slot.end,
+                        expected_solar_watts=slot.expected_solar_watts,
+                        expected_excess_watts=slot.expected_excess_watts,
+                        price=slot.price,
+                        is_cheap=slot.is_cheap,
+                    )
+                )
 
         return merged
 
@@ -234,8 +247,7 @@ class Planner:
         if charging_needed_kwh <= 0.0 or not timeline:
             # No charging needed or no slots to work with
             excess_after = {
-                i: self._slot_excess_kwh(slot)
-                for i, slot in enumerate(timeline)
+                i: self._slot_excess_kwh(slot) for i, slot in enumerate(timeline)
             }
             return BatteryAllocation(
                 charging_needed_kwh=charging_needed_kwh,
@@ -280,8 +292,7 @@ class Planner:
         Battery charges from whatever is left over (handled at runtime).
         """
         excess_after = {
-            i: self._slot_excess_kwh(slot)
-            for i, slot in enumerate(timeline)
+            i: self._slot_excess_kwh(slot) for i, slot in enumerate(timeline)
         }
         return BatteryAllocation(
             charging_needed_kwh=charging_needed_kwh,
@@ -350,7 +361,11 @@ class Planner:
                 # Calculate how much energy this slot can actually provide (based on duration)
                 slot_hours = (slot.end - slot.start).total_seconds() / 3600
                 # Assume C/4 charge rate (conservative 4-hour full charge), capped at 10 kW
-                max_charge_rate_kw = min(battery_config.capacity_kwh / 4, 10.0) if battery_config.capacity_kwh > 0 else 5.0
+                max_charge_rate_kw = (
+                    min(battery_config.capacity_kwh / 4, 10.0)
+                    if battery_config.capacity_kwh > 0
+                    else 5.0
+                )
                 slot_capacity = max_charge_rate_kw * slot_hours
                 can_provide = min(slot_capacity, remaining_need)
                 allocate = can_provide
@@ -450,7 +465,9 @@ class Planner:
         sorted_appliances = sorted(appliances, key=lambda a: a.priority)
 
         # Track remaining excess per slot (will be consumed as appliances are allocated)
-        remaining_excess: dict[int, float] = dict(battery_allocation.excess_after_battery)
+        remaining_excess: dict[int, float] = dict(
+            battery_allocation.excess_after_battery
+        )
 
         for appliance in sorted_appliances:
             app_entries = self._schedule_single_appliance(
@@ -487,10 +504,7 @@ class Planner:
 
         # Calculate energy needed in kWh
         energy_needed_kwh = (
-            appliance.nominal_power
-            * min_daily_runtime_seconds
-            / 3600.0
-            / 1000.0
+            appliance.nominal_power * min_daily_runtime_seconds / 3600.0 / 1000.0
         )
 
         if energy_needed_kwh <= 0:
@@ -502,12 +516,20 @@ class Planner:
         # Handle deadline-constrained scheduling
         if appliance.schedule_deadline is not None:
             return self._schedule_with_deadline(
-                timeline, remaining_excess, appliance, energy_needed_kwh, power_kwh_per_hour
+                timeline,
+                remaining_excess,
+                appliance,
+                energy_needed_kwh,
+                power_kwh_per_hour,
             )
 
         # Standard greedy scheduling (no deadline)
         return self._schedule_greedy(
-            timeline, remaining_excess, appliance, energy_needed_kwh, power_kwh_per_hour,
+            timeline,
+            remaining_excess,
+            appliance,
+            energy_needed_kwh,
+            power_kwh_per_hour,
             cheap_price_threshold,
         )
 
@@ -526,7 +548,8 @@ class Planner:
 
         # Tier 1: Slots with excess solar
         excess_slots = [
-            (i, slot) for i, slot in enumerate(timeline)
+            (i, slot)
+            for i, slot in enumerate(timeline)
             if remaining_excess.get(i, 0.0) > 0
         ]
         # Sort excess slots by most excess first for best utilization
@@ -537,21 +560,36 @@ class Planner:
                 break
             pre_excess = remaining_excess.get(idx, 0.0)
             consumed = self._allocate_slot(
-                slot, idx, remaining_excess, appliance, remaining_energy, power_kwh_per_hour
+                slot,
+                idx,
+                remaining_excess,
+                appliance,
+                remaining_energy,
+                power_kwh_per_hour,
             )
             if consumed > 0:
-                target_current = self._calculate_target_current(appliance, slot, pre_excess)
-                entries.append(PlanEntry(
-                    appliance_id=appliance.id,
-                    action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                    target_current=target_current if appliance.dynamic_current else None,
-                    window=TariffWindow(
-                        start=slot.start, end=slot.end,
-                        price=slot.price, is_cheap=slot.is_cheap,
-                    ),
-                    reason=PlanReason.EXCESS_AVAILABLE,
-                    priority=appliance.priority,
-                ))
+                target_current = self._calculate_target_current(
+                    appliance, slot, pre_excess
+                )
+                entries.append(
+                    PlanEntry(
+                        appliance_id=appliance.id,
+                        action=Action.SET_CURRENT
+                        if appliance.dynamic_current
+                        else Action.ON,
+                        target_current=target_current
+                        if appliance.dynamic_current
+                        else None,
+                        window=TariffWindow(
+                            start=slot.start,
+                            end=slot.end,
+                            price=slot.price,
+                            is_cheap=slot.is_cheap,
+                        ),
+                        reason=PlanReason.EXCESS_AVAILABLE,
+                        priority=appliance.priority,
+                    )
+                )
                 remaining_energy -= consumed
 
         # Tier 2: Cheap tariff slots (if grid supplementation allowed)
@@ -562,7 +600,8 @@ class Planner:
                 else cheap_price_threshold
             )
             cheap_slots = [
-                (i, slot) for i, slot in enumerate(timeline)
+                (i, slot)
+                for i, slot in enumerate(timeline)
                 if slot.price <= effective_threshold
             ]
             # Sort cheap slots by price ascending
@@ -586,18 +625,28 @@ class Planner:
                 slot_excess = remaining_excess.get(idx, 0.0)
                 consumed = min(power_kwh_per_hour * duration_hours, remaining_energy)
                 if consumed > 0:
-                    target_current = self._calculate_target_current(appliance, slot, slot_excess)
-                    entries.append(PlanEntry(
-                        appliance_id=appliance.id,
-                        action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                        target_current=target_current if appliance.dynamic_current else None,
-                        window=TariffWindow(
-                            start=slot.start, end=slot.end,
-                            price=slot.price, is_cheap=slot.is_cheap,
-                        ),
-                        reason=PlanReason.CHEAP_TARIFF,
-                        priority=appliance.priority,
-                    ))
+                    target_current = self._calculate_target_current(
+                        appliance, slot, slot_excess
+                    )
+                    entries.append(
+                        PlanEntry(
+                            appliance_id=appliance.id,
+                            action=Action.SET_CURRENT
+                            if appliance.dynamic_current
+                            else Action.ON,
+                            target_current=target_current
+                            if appliance.dynamic_current
+                            else None,
+                            window=TariffWindow(
+                                start=slot.start,
+                                end=slot.end,
+                                price=slot.price,
+                                is_cheap=slot.is_cheap,
+                            ),
+                            reason=PlanReason.CHEAP_TARIFF,
+                            priority=appliance.priority,
+                        )
+                    )
                     remaining_energy -= consumed
                     # Deduct solar portion from remaining excess (grid portion doesn't consume solar)
                     if slot_excess > 0:
@@ -606,9 +655,7 @@ class Planner:
 
         # Tier 3: Any remaining slots (for must-run appliances that still need runtime)
         if remaining_energy > 0 and appliance.min_daily_runtime is not None:
-            all_slots = [
-                (i, slot) for i, slot in enumerate(timeline)
-            ]
+            all_slots = [(i, slot) for i, slot in enumerate(timeline)]
             # Sort by price ascending
             all_slots.sort(key=lambda x: x[1].price)
 
@@ -630,18 +677,28 @@ class Planner:
                 slot_excess = remaining_excess.get(idx, 0.0)
                 consumed = min(power_kwh_per_hour * duration_hours, remaining_energy)
                 if consumed > 0:
-                    target_current = self._calculate_target_current(appliance, slot, slot_excess)
-                    entries.append(PlanEntry(
-                        appliance_id=appliance.id,
-                        action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                        target_current=target_current if appliance.dynamic_current else None,
-                        window=TariffWindow(
-                            start=slot.start, end=slot.end,
-                            price=slot.price, is_cheap=slot.is_cheap,
-                        ),
-                        reason=PlanReason.MIN_RUNTIME,
-                        priority=appliance.priority,
-                    ))
+                    target_current = self._calculate_target_current(
+                        appliance, slot, slot_excess
+                    )
+                    entries.append(
+                        PlanEntry(
+                            appliance_id=appliance.id,
+                            action=Action.SET_CURRENT
+                            if appliance.dynamic_current
+                            else Action.ON,
+                            target_current=target_current
+                            if appliance.dynamic_current
+                            else None,
+                            window=TariffWindow(
+                                start=slot.start,
+                                end=slot.end,
+                                price=slot.price,
+                                is_cheap=slot.is_cheap,
+                            ),
+                            reason=PlanReason.MIN_RUNTIME,
+                            priority=appliance.priority,
+                        )
+                    )
                     remaining_energy -= consumed
                     # Deduct solar portion from remaining excess (grid portion doesn't consume solar)
                     if slot_excess > 0:
@@ -673,7 +730,13 @@ class Planner:
         # A deadline before noon suggests overnight scheduling (e.g., "EV by 7am")
         is_overnight = deadline < time(12, 0)
         for i, slot in enumerate(timeline):
-            slot_start_time = slot.start.astimezone(self.tz).time() if hasattr(slot.start, 'astimezone') else slot.start.time() if hasattr(slot.start, 'time') else slot.start
+            slot_start_time = (
+                slot.start.astimezone(self.tz).time()
+                if hasattr(slot.start, "astimezone")
+                else slot.start.time()
+                if hasattr(slot.start, "time")
+                else slot.start
+            )
             if is_overnight:
                 # For overnight: include slots starting before deadline OR after noon (afternoon/evening/night)
                 if slot_start_time < deadline or slot_start_time >= time(12, 0):
@@ -687,7 +750,8 @@ class Planner:
             _LOGGER.warning(
                 "No eligible slots before deadline %s for appliance %s "
                 "(deadline may be past)",
-                deadline, appliance.name,
+                deadline,
+                appliance.name,
             )
             return []
 
@@ -717,24 +781,39 @@ class Planner:
             reason = PlanReason.DEADLINE
             if slot_excess > 0:
                 consumed = self._allocate_slot(
-                    slot, idx, remaining_excess, appliance, remaining_energy, power_kwh_per_hour
+                    slot,
+                    idx,
+                    remaining_excess,
+                    appliance,
+                    remaining_energy,
+                    power_kwh_per_hour,
                 )
             else:
                 consumed = min(power_kwh_per_hour * duration_hours, remaining_energy)
 
             if consumed > 0:
-                target_current = self._calculate_target_current(appliance, slot, slot_excess)
-                entries.append(PlanEntry(
-                    appliance_id=appliance.id,
-                    action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                    target_current=target_current if appliance.dynamic_current else None,
-                    window=TariffWindow(
-                        start=slot.start, end=slot.end,
-                        price=slot.price, is_cheap=slot.is_cheap,
-                    ),
-                    reason=reason,
-                    priority=appliance.priority,
-                ))
+                target_current = self._calculate_target_current(
+                    appliance, slot, slot_excess
+                )
+                entries.append(
+                    PlanEntry(
+                        appliance_id=appliance.id,
+                        action=Action.SET_CURRENT
+                        if appliance.dynamic_current
+                        else Action.ON,
+                        target_current=target_current
+                        if appliance.dynamic_current
+                        else None,
+                        window=TariffWindow(
+                            start=slot.start,
+                            end=slot.end,
+                            price=slot.price,
+                            is_cheap=slot.is_cheap,
+                        ),
+                        reason=reason,
+                        priority=appliance.priority,
+                    )
+                )
                 remaining_energy -= consumed
 
         return entries
@@ -858,7 +937,6 @@ class Planner:
 
             # Check if this appliance already has enough entries
             app_entries = [e for e in entries if e.appliance_id == appliance.id]
-            current_slots = len(app_entries)
 
             # Calculate how many additional slots to add based on how poor
             # tomorrow is. More poor = more additional slots.
@@ -901,18 +979,28 @@ class Planner:
 
                 if consumed > 0:
                     remaining_excess[i] = slot_excess - consumed
-                    target_current = self._calculate_target_current(appliance, slot, slot_excess)
-                    additional_entries.append(PlanEntry(
-                        appliance_id=appliance.id,
-                        action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                        target_current=target_current if appliance.dynamic_current else None,
-                        window=TariffWindow(
-                            start=slot.start, end=slot.end,
-                            price=slot.price, is_cheap=slot.is_cheap,
-                        ),
-                        reason=PlanReason.WEATHER_PREPLANNING,
-                        priority=appliance.priority,
-                    ))
+                    target_current = self._calculate_target_current(
+                        appliance, slot, slot_excess
+                    )
+                    additional_entries.append(
+                        PlanEntry(
+                            appliance_id=appliance.id,
+                            action=Action.SET_CURRENT
+                            if appliance.dynamic_current
+                            else Action.ON,
+                            target_current=target_current
+                            if appliance.dynamic_current
+                            else None,
+                            window=TariffWindow(
+                                start=slot.start,
+                                end=slot.end,
+                                price=slot.price,
+                                is_cheap=slot.is_cheap,
+                            ),
+                            reason=PlanReason.WEATHER_PREPLANNING,
+                            priority=appliance.priority,
+                        )
+                    )
                     extra_energy_needed -= consumed
 
         return entries + additional_entries
@@ -994,17 +1082,25 @@ class Planner:
                     target_current = self._calculate_target_current(
                         appliance, slot, curtailed_watts * duration_hours / 1000.0
                     )
-                    additional_entries.append(PlanEntry(
-                        appliance_id=appliance.id,
-                        action=Action.SET_CURRENT if appliance.dynamic_current else Action.ON,
-                        target_current=target_current if appliance.dynamic_current else None,
-                        window=TariffWindow(
-                            start=slot.start, end=slot.end,
-                            price=slot.price, is_cheap=slot.is_cheap,
-                        ),
-                        reason=PlanReason.EXPORT_LIMIT,
-                        priority=appliance.priority,
-                    ))
+                    additional_entries.append(
+                        PlanEntry(
+                            appliance_id=appliance.id,
+                            action=Action.SET_CURRENT
+                            if appliance.dynamic_current
+                            else Action.ON,
+                            target_current=target_current
+                            if appliance.dynamic_current
+                            else None,
+                            window=TariffWindow(
+                                start=slot.start,
+                                end=slot.end,
+                                price=slot.price,
+                                is_cheap=slot.is_cheap,
+                            ),
+                            reason=PlanReason.EXPORT_LIMIT,
+                            priority=appliance.priority,
+                        )
+                    )
                     # Update remaining excess
                     slot_excess = remaining_excess.get(idx, 0.0)
                     remaining_excess[idx] = max(slot_excess - consumed, 0.0)
@@ -1070,8 +1166,7 @@ class Planner:
                 charging_needed_kwh=0.0,
                 slots_reserved=[],
                 excess_after_battery={
-                    i: self._slot_excess_kwh(slot)
-                    for i, slot in enumerate(timeline)
+                    i: self._slot_excess_kwh(slot) for i, slot in enumerate(timeline)
                 },
             )
             battery_target = BatteryTarget(
@@ -1082,7 +1177,9 @@ class Planner:
 
         # 3. Schedule appliances
         entries = self.schedule_appliances(
-            timeline, battery_allocation, appliances,
+            timeline,
+            battery_allocation,
+            appliances,
             cheap_price_threshold=tariff.cheap_price_threshold,
         )
 
@@ -1097,7 +1194,12 @@ class Planner:
 
         # 5. Apply export limit management
         entries = self.apply_export_limit(
-            entries, timeline, remaining_excess, appliances, export_limit, base_load_watts
+            entries,
+            timeline,
+            remaining_excess,
+            appliances,
+            export_limit,
+            base_load_watts,
         )
 
         # 6. Calculate confidence and build plan
@@ -1120,7 +1222,9 @@ class Planner:
         )
         _LOGGER.debug(
             "Planner: %d timeline slots, %d plan entries, confidence=%.1f%%",
-            len(timeline), len(plan.entries), plan.confidence * 100,
+            len(timeline),
+            len(plan.entries),
+            plan.confidence * 100,
         )
         return plan
 
@@ -1146,7 +1250,9 @@ class Planner:
                 if slot.start == entry.window.start and slot.end == entry.window.end:
                     current = remaining_excess.get(i, 0.0)
                     if current > 0:
-                        duration_hours = (slot.end - slot.start).total_seconds() / 3600.0
+                        duration_hours = (
+                            slot.end - slot.start
+                        ).total_seconds() / 3600.0
                         power = app_power.get(entry.appliance_id, 0.0)
                         consumed_kwh = power / 1000.0 * duration_hours
                         remaining_excess[i] = max(current - consumed_kwh, 0.0)
@@ -1181,7 +1287,9 @@ class Planner:
             confidence += min(coverage, 1.0) * 0.2
 
         # Reduce if many entries depend on uncertain sources
-        excess_entries = sum(1 for e in entries if e.reason == PlanReason.EXCESS_AVAILABLE)
+        excess_entries = sum(
+            1 for e in entries if e.reason == PlanReason.EXCESS_AVAILABLE
+        )
         total_entries = len(entries)
         if total_entries > 0:
             forecast_dependency = excess_entries / total_entries

--- a/custom_components/pv_excess_control/select.py
+++ b/custom_components/pv_excess_control/select.py
@@ -1,4 +1,5 @@
 """Select platform for PV Excess Control."""
+
 from __future__ import annotations
 
 import logging
@@ -10,7 +11,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BatteryStrategy, CONF_BATTERY_STRATEGY, DOMAIN, MANUFACTURER
+from .const import CONF_BATTERY_STRATEGY, DOMAIN, MANUFACTURER
 from .coordinator import PvExcessCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/pv_excess_control/sensor.py
+++ b/custom_components/pv_excess_control/sensor.py
@@ -4,6 +4,7 @@ Exposes coordinator data as Home Assistant sensor entities:
 - System-level sensors (excess power, plan confidence, etc.)
 - Per-appliance sensors (power, runtime, energy, status)
 """
+
 from __future__ import annotations
 
 import logging
@@ -52,14 +53,18 @@ async def async_setup_entry(
     # Per-appliance sensors from subentries
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
-        appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.extend([
-            PvAppliancePowerSensor(coordinator, subentry_id, appliance_name),
-            PvApplianceRuntimeSensor(coordinator, subentry_id, appliance_name),
-            PvApplianceEnergySensor(coordinator, subentry_id, appliance_name),
-            PvApplianceActivationsSensor(coordinator, subentry_id, appliance_name),
-            PvApplianceStatusSensor(coordinator, subentry_id, appliance_name),
-        ])
+        appliance_name = subentry.data.get(
+            CONF_APPLIANCE_NAME, f"Appliance {subentry_id}"
+        )
+        entities.extend(
+            [
+                PvAppliancePowerSensor(coordinator, subentry_id, appliance_name),
+                PvApplianceRuntimeSensor(coordinator, subentry_id, appliance_name),
+                PvApplianceEnergySensor(coordinator, subentry_id, appliance_name),
+                PvApplianceActivationsSensor(coordinator, subentry_id, appliance_name),
+                PvApplianceStatusSensor(coordinator, subentry_id, appliance_name),
+            ]
+        )
 
     async_add_entities(entities)
 
@@ -162,13 +167,21 @@ class PvPlanConfidenceSensor(PvExcessBaseSensor):
         for entry in plan.entries:
             e: dict[str, Any] = {
                 "appliance_id": entry.appliance_id,
-                "appliance_name": configs[entry.appliance_id].name if entry.appliance_id in configs else entry.appliance_id,
-                "action": entry.action.value if hasattr(entry.action, 'value') else str(entry.action),
+                "appliance_name": configs[entry.appliance_id].name
+                if entry.appliance_id in configs
+                else entry.appliance_id,
+                "action": entry.action.value
+                if hasattr(entry.action, "value")
+                else str(entry.action),
                 "reason": entry.reason,
             }
             if entry.window:
-                e["window_start"] = entry.window.start.isoformat() if entry.window.start else None
-                e["window_end"] = entry.window.end.isoformat() if entry.window.end else None
+                e["window_start"] = (
+                    entry.window.start.isoformat() if entry.window.start else None
+                )
+                e["window_end"] = (
+                    entry.window.end.isoformat() if entry.window.end else None
+                )
             entries.append(e)
         return {"plan_entries": entries, "plan_entry_count": len(plan.entries)}
 
@@ -240,7 +253,9 @@ class PvApplianceRuntimeSensor(PvApplianceBaseSensor):
         appliance_id: str,
         appliance_name: str,
     ) -> None:
-        super().__init__(coordinator, appliance_id, appliance_name, "runtime_today", "Runtime Today")
+        super().__init__(
+            coordinator, appliance_id, appliance_name, "runtime_today", "Runtime Today"
+        )
 
     @property
     def native_value(self) -> float | None:
@@ -265,12 +280,15 @@ class PvApplianceEnergySensor(PvApplianceBaseSensor):
         appliance_id: str,
         appliance_name: str,
     ) -> None:
-        super().__init__(coordinator, appliance_id, appliance_name, "energy_today", "Energy Today")
+        super().__init__(
+            coordinator, appliance_id, appliance_name, "energy_today", "Energy Today"
+        )
 
     @property
     def last_reset(self):
         """Return the start of today (timezone-aware) for daily-resetting energy counter."""
         from homeassistant.util import dt as dt_util
+
         return dt_util.start_of_local_day()
 
     @property
@@ -293,7 +311,13 @@ class PvApplianceActivationsSensor(PvApplianceBaseSensor):
         appliance_id: str,
         appliance_name: str,
     ) -> None:
-        super().__init__(coordinator, appliance_id, appliance_name, "activations_today", "Activations Today")
+        super().__init__(
+            coordinator,
+            appliance_id,
+            appliance_name,
+            "activations_today",
+            "Activations Today",
+        )
 
     @property
     def native_value(self) -> int | None:

--- a/custom_components/pv_excess_control/status_formatter.py
+++ b/custom_components/pv_excess_control/status_formatter.py
@@ -10,6 +10,7 @@ and optional Plan, and returns a FormattedStatus containing:
 
 See docs/specs/2026-04-06-status-sensor-enhancements-design.md.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ class FormattedStatus:
     `text` is the decorated state string for the HA sensor state.
     The other fields map 1:1 to sensor extra_state_attributes.
     """
+
     text: str
     action: str
     overrides_plan: bool
@@ -108,15 +110,13 @@ def format_status(
     )
     if switch_deferred:
         suffixes.append(
-            f" (switch deferred - "
-            f"{format_duration(cooldown_remaining)} cooldown)"
+            f" (switch deferred - {format_duration(cooldown_remaining)} cooldown)"
         )
 
     # --- S3: battery discharge soft-limit suffix ---
     if _should_show_battery_limit(decision, config, battery_action):
         suffixes.append(
-            f" [battery discharge limited to "
-            f"{battery_action.max_discharge_watts:.0f}W]"
+            f" [battery discharge limited to {battery_action.max_discharge_watts:.0f}W]"
         )
 
     # --- S4: plan deviation suffix ---
@@ -146,8 +146,7 @@ def format_status(
                 start = matched.window.start.strftime("%H:%M")
                 end = matched.window.end.strftime("%H:%M")
                 suffixes.append(
-                    f" [plan wanted: {plan_action_display} "
-                    f"during {start}-{end}]"
+                    f" [plan wanted: {plan_action_display} during {start}-{end}]"
                 )
             else:
                 suffixes.append(f" [plan wanted: {plan_action_display}]")
@@ -266,9 +265,7 @@ def _should_show_battery_limit(
         return False
     if not config.is_big_consumer:
         return False
-    if "Battery SoC protection" in decision.reason:
-        return False
-    return True
+    return "Battery SoC protection" not in decision.reason
 
 
 def _find_matching_plan_entry(
@@ -306,11 +303,11 @@ def _find_matching_plan_entry(
             now_naive = now.replace(tzinfo=None)
             start_naive = (
                 window.start.replace(tzinfo=None)
-                if window.start.tzinfo else window.start
+                if window.start.tzinfo
+                else window.start
             )
             end_naive = (
-                window.end.replace(tzinfo=None)
-                if window.end.tzinfo else window.end
+                window.end.replace(tzinfo=None) if window.end.tzinfo else window.end
             )
             if start_naive <= now_naive <= end_naive:
                 return entry

--- a/custom_components/pv_excess_control/switch.py
+++ b/custom_components/pv_excess_control/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for PV Excess Control."""
+
 from __future__ import annotations
 
 import logging
@@ -11,7 +12,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_APPLIANCE_NAME, CONF_BATTERY_GRID_CHARGE_POWER_W, DOMAIN, MANUFACTURER
+from contextlib import suppress
+
+from .const import (
+    CONF_APPLIANCE_NAME,
+    CONF_BATTERY_GRID_CHARGE_POWER_W,
+    DOMAIN,
+    MANUFACTURER,
+)
 from .coordinator import PvExcessCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,9 +41,15 @@ async def async_setup_entry(
     # Per-appliance switches
     subentries = getattr(config_entry, "subentries", {})
     for subentry_id, subentry in subentries.items():
-        appliance_name = subentry.data.get(CONF_APPLIANCE_NAME, f"Appliance {subentry_id}")
-        entities.append(ApplianceEnabledSwitch(coordinator, subentry_id, appliance_name))
-        entities.append(ApplianceOverrideSwitch(coordinator, subentry_id, appliance_name))
+        appliance_name = subentry.data.get(
+            CONF_APPLIANCE_NAME, f"Appliance {subentry_id}"
+        )
+        entities.append(
+            ApplianceEnabledSwitch(coordinator, subentry_id, appliance_name)
+        )
+        entities.append(
+            ApplianceOverrideSwitch(coordinator, subentry_id, appliance_name)
+        )
 
     async_add_entities(entities)
 
@@ -114,7 +128,9 @@ class ForceChargeSwitch(_PvExcessSwitchBase):
             self.coordinator._inverter_ctl is not None
             and not self.coordinator._grid_charge_engaged
         ):
-            power_w = self.coordinator.config_entry.data.get(CONF_BATTERY_GRID_CHARGE_POWER_W)
+            power_w = self.coordinator.config_entry.data.get(
+                CONF_BATTERY_GRID_CHARGE_POWER_W
+            )
             if power_w is not None:
                 await self.coordinator._inverter_ctl.engage(power_w)
                 self.coordinator._grid_charge_engaged = True
@@ -163,7 +179,8 @@ class ApplianceEnabledSwitch(_PvExcessSwitchBase):
     def _persist_disabled_list(self) -> None:
         """Persist the list of disabled appliance IDs to config_entry.data."""
         disabled = [
-            aid for aid, enabled in self.coordinator.appliance_enabled.items()
+            aid
+            for aid, enabled in self.coordinator.appliance_enabled.items()
             if not enabled
         ]
         self._persist("disabled_appliances", disabled)
@@ -181,12 +198,13 @@ class ApplianceEnabledSwitch(_PvExcessSwitchBase):
         if config and config.entity_id:
             entity_id = config.entity_id
             domain = entity_id.split(".")[0] if "." in entity_id else "switch"
-            try:
+            with suppress(Exception):
                 await self.hass.services.async_call(
-                    domain, "turn_off", {"entity_id": entity_id}, blocking=True,
+                    domain,
+                    "turn_off",
+                    {"entity_id": entity_id},
+                    blocking=True,
                 )
-            except Exception:
-                pass  # Best effort
         self.async_write_ha_state()
 
 
@@ -216,8 +234,7 @@ class ApplianceOverrideSwitch(_PvExcessSwitchBase):
     def _persist_overridden_list(self) -> None:
         """Persist the list of overridden appliance IDs to config_entry.data."""
         overridden = [
-            aid for aid, ov in self.coordinator.appliance_overrides.items()
-            if ov
+            aid for aid, ov in self.coordinator.appliance_overrides.items() if ov
         ]
         self._persist("overridden_appliances", overridden)
 

--- a/custom_components/pv_excess_control/translations/en.json
+++ b/custom_components/pv_excess_control/translations/en.json
@@ -53,9 +53,9 @@
         "data_description": {
           "tariff_provider": "Select your electricity price provider integration.",
           "price_sensor": "Select the sensor entity that provides the current electricity price. For Tibber, use the price sensor. For Octopus, select the electricity price sensor. For Awattar/Nordpool, select the spot price sensor.",
-          "cheap_price_threshold": "Price below which electricity is considered cheap.",
-          "battery_charge_price_threshold": "Price below which battery charging from grid is allowed.",
-          "feed_in_tariff": "Price received per kWh for energy exported to the grid.",
+          "cheap_price_threshold": "Price below which electricity is considered cheap. Example: 0.1 (10 Cent)",
+          "battery_charge_price_threshold": "Price below which battery charging from grid is allowed. Example: 0.1 (10 Cent)",
+          "feed_in_tariff": "Price received per kWh for energy exported to the grid. Example: 0.081 (8.1 Cent)",
           "feed_in_tariff_sensor": "Optional sensor for dynamic feed-in tariff (overrides static value)"
         }
       },
@@ -175,7 +175,7 @@
             "appliance_name": "A friendly name for this appliance.",
             "appliance_entity": "The switch or controllable entity for this appliance.",
             "appliance_priority": "Lower number = higher priority. Appliances with higher priority get excess power first.",
-            "nominal_power": "The rated power consumption of this appliance in watts.",
+            "nominal_power": "The rated power consumption of this appliance in watts. For dynamic current devices use max power.",
             "actual_power_entity": "Optional sensor that reports actual power consumption (W or kW — automatically converted).",
             "phases": "Number of electrical phases this appliance uses."
           }

--- a/docs/advanced/how-it-works.md
+++ b/docs/advanced/how-it-works.md
@@ -34,12 +34,14 @@ The **Planner** runs less frequently and builds a 24-hour schedule:
 Each Controller cycle runs the Optimizer through four phases:
 
 ### Phase 1: ASSESS
+
 - Averages excess power over recent history to smooth sensor noise
 - Applies **hysteresis**: requires excess > `ON_THRESHOLD` (default 200 W) to turn on, and excess < `OFF_THRESHOLD` (default -50 W) to turn off
 - Checks if each appliance is within its min/max runtime constraints
 - Checks switch interval (don't switch more often than configured)
 
 ### Phase 2: ALLOCATE
+
 - Sorts appliances by priority (1 = highest)
 - For each appliance (highest priority first): allocates available excess
 - For dynamic current appliances: calculates the optimal current
@@ -48,10 +50,12 @@ Each Controller cycle runs the Optimizer through four phases:
 - Can activate appliances during cheap tariff windows even without solar excess
 
 ### Phase 3: SHED
+
 - If total power draw exceeds available excess, reduces current on dynamic appliances
 - If still over-budget, turns off lowest-priority appliances first
 
 ### Phase 4: BATTERY DISCHARGE PROTECTION
+
 - If any "big consumer" appliance is running, checks if the battery discharge should be limited
 - Issues a `BatteryDischargeAction` to cap the battery output
 
@@ -62,14 +66,17 @@ Each Controller cycle runs the Optimizer through four phases:
 The **Plan Influence** setting controls how much the planner's 24-hour schedule affects the optimizer's real-time decisions. Configure it in Settings -> PV Excess Control -> Global Settings.
 
 ### None (Pure Reactive)
+
 The optimizer completely ignores the plan. Decisions are based only on current excess power and tariff. Use this if you don't have a forecast provider configured or prefer pure reactive control.
 
 ### Light (Default)
+
 When the plan schedules an appliance to be ON in the current time slot, the optimizer **lowers the activation threshold**. Normally an appliance needs `nominal_power + 200W` of excess to turn on. With `light` mode and a plan match, it only needs `nominal_power` (the 200W buffer is removed). The plan never forces an appliance ON without any excess -- it just makes the optimizer more willing.
 
 **Best for:** Most users. Gets the benefit of forecast data (Solcast, tariff schedules) without the risk of unexpected grid consumption.
 
 ### Plan Follows (Schedule-Driven)
+
 The optimizer actively follows the plan. If the plan schedules an appliance ON based on forecast or cheap tariff windows, it activates even without full solar excess. The optimizer overrides only when actual conditions deviate significantly from the forecast.
 
 **Best for:** Users with reliable forecast data (Solcast with good accuracy) and tariff providers, who want maximum automation.
@@ -89,6 +96,7 @@ OptimizerResult (list of ControlDecisions)
 ```
 
 This means:
+
 - The optimizer can be unit-tested without any HA mocking
 - The same optimizer logic runs in tests and production
 - Logic bugs are caught at the unit test level, not during runtime
@@ -123,7 +131,7 @@ Controller.build_power_state()
 
 ## Plan vs. Real-Time
 
-The Controller always runs real-time control. The Plan is a *guide*, not a hard constraint. If real conditions deviate from the plan:
+The Controller always runs real-time control. The Plan is a _guide_, not a hard constraint. If real conditions deviate from the plan:
 
 - Real excess < planned: the Controller sheds appliances immediately
 - Real excess > planned: the Controller allocates extra power by priority

--- a/docs/advanced/priority-guide.md
+++ b/docs/advanced/priority-guide.md
@@ -6,20 +6,21 @@ Priority is the central mechanism for deciding which appliances run first when s
 
 ## The Priority Scale
 
-| Priority | Use for |
-|----------|---------|
-| 1–10 | Must-run: EV with deadline, medical devices, critical loads |
-| 11–30 | High-value: EV without deadline, heat pump, hot water |
-| 31–60 | Medium: dishwasher, washing machine, dryer |
-| 61–100 | Low: pool pump, garden irrigation, secondary loads |
-| 101–500 | Background: plug-in heaters, miscellaneous |
-| 501–1000 | Lowest: anything that should only run with strong excess |
+| Priority | Use for                                                     |
+| -------- | ----------------------------------------------------------- |
+| 1–10     | Must-run: EV with deadline, medical devices, critical loads |
+| 11–30    | High-value: EV without deadline, heat pump, hot water       |
+| 31–60    | Medium: dishwasher, washing machine, dryer                  |
+| 61–100   | Low: pool pump, garden irrigation, secondary loads          |
+| 101–500  | Background: plug-in heaters, miscellaneous                  |
+| 501–1000 | Lowest: anything that should only run with strong excess    |
 
 ---
 
 ## How Priority Affects Decisions
 
 ### Allocation (turning on)
+
 When excess power becomes available, the optimizer fills appliances from **lowest priority number** (highest priority) first:
 
 1. EV Charger (priority 10) turns on and gets as many watts as it needs
@@ -28,6 +29,7 @@ When excess power becomes available, the optimizer fills appliances from **lowes
 4. And so on, until excess is exhausted
 
 ### Shedding (turning off)
+
 When excess drops and appliances must be shed, the optimizer sheds from **highest priority number** (lowest priority) first:
 
 1. Pool Pump (priority 100) is turned off first
@@ -35,6 +37,7 @@ When excess drops and appliances must be shed, the optimizer sheds from **highes
 3. And so on, preserving the highest-priority appliances
 
 ### Dynamic Current Adjustment
+
 For EV chargers with dynamic current, current is reduced before shedding:
 
 1. EV Charger current is reduced from 16 A → 12 A → 8 A → 6 A
@@ -44,32 +47,36 @@ For EV chargers with dynamic current, current is reduced before shedding:
 
 ## Real-World Example: House with EV, Heat Pump, Dishwasher, Pool
 
-| Appliance | Priority | Power |
-|-----------|----------|-------|
-| EV Charger | 10 | up to 11 kW |
-| Heat Pump | 20 | 2 kW |
-| Dishwasher | 50 | 1.8 kW |
-| Pool Pump | 100 | 0.8 kW |
+| Appliance  | Priority | Power       |
+| ---------- | -------- | ----------- |
+| EV Charger | 10       | up to 11 kW |
+| Heat Pump  | 20       | 2 kW        |
+| Dishwasher | 50       | 1.8 kW      |
+| Pool Pump  | 100      | 0.8 kW      |
 
 **At 6 kW excess:**
+
 - EV Charger: ON at ~6A (3-phase, consuming ~4 kW)
 - Heat Pump: ON (2 kW)
 - Dishwasher: OFF — not enough remaining excess
 - Pool Pump: OFF
 
 **At 9 kW excess:**
+
 - EV Charger: ON at ~10A (consuming ~7 kW)
 - Heat Pump: ON (2 kW)
 - Dishwasher: OFF — just below threshold
 - Pool Pump: OFF
 
 **At 12 kW excess:**
+
 - EV Charger: ON at ~14A (consuming ~10 kW)
 - Heat Pump: ON (2 kW)
 - Dishwasher: OFF (only 0 W remaining — use ON_THRESHOLD = 200 W)
 - Pool Pump: OFF
 
 **At 15 kW excess:**
+
 - EV Charger: ON at 16A (11 kW max)
 - Heat Pump: ON (2 kW)
 - Dishwasher: ON (1.8 kW)
@@ -80,7 +87,7 @@ For EV chargers with dynamic current, current is reduced before shedding:
 
 ## Adjusting Priorities
 
-Think of priority as answering: *"When excess is limited and I have to choose, which appliance matters most?"*
+Think of priority as answering: _"When excess is limited and I have to choose, which appliance matters most?"_
 
 **EV should be higher priority than pool pump** — you need the car charged, but the pool can wait.
 

--- a/docs/advanced/troubleshooting.md
+++ b/docs/advanced/troubleshooting.md
@@ -29,6 +29,7 @@ After restarting, the log will show every optimizer cycle, including excess calc
 In Developer Tools → States, find `sensor.pv_excess_control_excess_power`. If it is 0 or negative when solar is producing, the sensor mapping is wrong.
 
 Common causes:
+
 - Wrong sign convention on grid sensor (see [Sensor Mapping](../configuration/sensor-mapping.md))
 - PV power sensor is unavailable — integration defaults to 0
 - Load power sensor included when it should not be (if using Import/Export, load power is implicit)
@@ -48,6 +49,7 @@ An appliance that was recently turned off will not turn on again until the switc
 **Problem**: Appliance turns on/off repeatedly every few minutes.
 
 **Fixes**:
+
 1. Increase **Switch Interval** to 300–600 s for the appliance
 2. The ON threshold (200 W) and OFF threshold (-50 W) provide built-in hysteresis to prevent flip-flopping
 3. If the appliance is still switching too frequently, check that the switch interval has not been set too low
@@ -105,6 +107,7 @@ ERROR (MainThread) [homeassistant.loader] ...
 ```
 
 Common causes:
+
 - Home Assistant version below 2025.8
 - Missing dependency in `manifest.json` (check version against the integration's requirements)
 - Syntax error in custom template sensors that the integration reads

--- a/docs/cheap-tariff-features.md
+++ b/docs/cheap-tariff-features.md
@@ -14,12 +14,12 @@ PV Excess Control responds to cheap (or negative) tariff windows in three ways:
 
 ## Per-appliance settings
 
-| Field                       | Where        | Effect                                                                                |
-|-----------------------------|--------------|---------------------------------------------------------------------------------------|
-| `allow_grid_supplement`     | appliance    | Master gate for *any* grid import on that appliance.                                  |
-| `cheap_price_threshold`     | appliance    | Per-appliance cheap threshold (overrides the global one if set).                      |
-| `max_grid_power`            | appliance    | Hard cap on grid contribution (newly meaningful on dynamic appliances since v…).      |
-| `cheap_grid_target_current` | dynamic only | Target current during cheap windows; defaults to `max_current` on new entries.        |
+| Field                       | Where        | Effect                                                                           |
+| --------------------------- | ------------ | -------------------------------------------------------------------------------- |
+| `allow_grid_supplement`     | appliance    | Master gate for _any_ grid import on that appliance.                             |
+| `cheap_price_threshold`     | appliance    | Per-appliance cheap threshold (overrides the global one if set).                 |
+| `max_grid_power`            | appliance    | Hard cap on grid contribution (newly meaningful on dynamic appliances since v…). |
+| `cheap_grid_target_current` | dynamic only | Target current during cheap windows; defaults to `max_current` on new entries.   |
 
 ### Migration note for existing dynamic-current appliances
 
@@ -32,14 +32,14 @@ the old min-current behaviour explicitly, set
 
 ## Battery settings
 
-| Field                                 | Effect                                                     |
-|---------------------------------------|------------------------------------------------------------|
-| `battery_charge_price_threshold`      | Cheap-window threshold for battery decisions.              |
-| `battery_target_soc`                  | Auto-engage stops once SoC reaches this.                   |
-| `auto_battery_grid_charge`            | Master toggle for the new auto behaviour.                  |
-| `battery_grid_charge_power_w`         | Power written to the inverter on engage.                   |
-| `grid_charge_engage_min_duration_minutes` | Hysteresis floor before disengage is allowed.          |
-| `inverter_force_charge_*` (3 triplets)| Wiring to your inverter's HA entities.                     |
+| Field                                     | Effect                                        |
+| ----------------------------------------- | --------------------------------------------- |
+| `battery_charge_price_threshold`          | Cheap-window threshold for battery decisions. |
+| `battery_target_soc`                      | Auto-engage stops once SoC reaches this.      |
+| `auto_battery_grid_charge`                | Master toggle for the new auto behaviour.     |
+| `battery_grid_charge_power_w`             | Power written to the inverter on engage.      |
+| `grid_charge_engage_min_duration_minutes` | Hysteresis floor before disengage is allowed. |
+| `inverter_force_charge_*` (3 triplets)    | Wiring to your inverter's HA entities.        |
 
 ## Worked example: production-style setup
 

--- a/docs/configuration/adding-appliances.md
+++ b/docs/configuration/adding-appliances.md
@@ -15,14 +15,14 @@ The appliance will appear as a device in Home Assistant with its own switch, sen
 
 ## Core Fields
 
-| Field | Description |
-|-------|-------------|
-| **Name** | Friendly name (e.g. "EV Charger", "Heat Pump") |
-| **Switch Entity** | The `switch` or `input_boolean` that turns the appliance on/off |
-| **Priority** | 1 = highest priority, 1000 = lowest. Lower priority appliances turn on first when excess is available and shed first when excess drops. |
-| **Nominal Power** | Expected wattage when running (used for planning and excess calculation) |
-| **Actual Power Sensor** | Optional: a power sensor for real-time consumption tracking (W or kW — automatically converted) |
-| **Phases** | 1 or 3 — used to convert amps to watts for dynamic current |
+| Field                   | Description                                                                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Name**                | Friendly name (e.g. "EV Charger", "Heat Pump")                                                                                          |
+| **Switch Entity**       | The `switch` or `input_boolean` that turns the appliance on/off                                                                         |
+| **Priority**            | 1 = highest priority, 1000 = lowest. Lower priority appliances turn on first when excess is available and shed first when excess drops. |
+| **Nominal Power**       | Expected wattage when running (used for planning and excess calculation)                                                                |
+| **Actual Power Sensor** | Optional: a power sensor for real-time consumption tracking (W or kW — automatically converted)                                         |
+| **Phases**              | 1 or 3 — used to convert amps to watts for dynamic current                                                                              |
 
 ---
 
@@ -30,11 +30,11 @@ The appliance will appear as a device in Home Assistant with its own switch, sen
 
 Enable **Dynamic Current** for appliances that accept variable amperage:
 
-| Field | Description |
-|-------|-------------|
+| Field              | Description                                     |
+| ------------------ | ----------------------------------------------- |
 | **Current Entity** | The `number` entity that controls charging amps |
-| **Min Current** | Minimum amps to use (e.g. 6 A — EVSE minimum) |
-| **Max Current** | Maximum amps to use (e.g. 16 A or 32 A) |
+| **Min Current**    | Minimum amps to use (e.g. 6 A — EVSE minimum)   |
+| **Max Current**    | Maximum amps to use (e.g. 16 A or 32 A)         |
 
 The optimizer will adjust current up and down every cycle to precisely consume available excess rather than switching on/off.
 
@@ -42,11 +42,11 @@ The optimizer will adjust current up and down every cycle to precisely consume a
 
 ## EV-Specific Fields
 
-| Field | Description |
-|-------|-------------|
-| **EV SoC Sensor** | A sensor showing the EV's battery percentage (0-100) |
-| **EV Connected Sensor** | A binary sensor -- True when the car is plugged in |
-| **EV Target SoC** | Target battery percentage (e.g., 80). Charging stops when the EV's SoC reaches or exceeds this value. |
+| Field                   | Description                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| **EV SoC Sensor**       | A sensor showing the EV's battery percentage (0-100)                                                  |
+| **EV Connected Sensor** | A binary sensor -- True when the car is plugged in                                                    |
+| **EV Target SoC**       | Target battery percentage (e.g., 80). Charging stops when the EV's SoC reaches or exceeds this value. |
 
 When the EV is not connected, the appliance is automatically skipped. When SoC reaches the configured target, charging stops.
 
@@ -54,12 +54,12 @@ When the EV is not connected, the appliance is automatically skipped. When SoC r
 
 ## Runtime Constraints
 
-| Field | Description |
-|-------|-------------|
-| **Min Daily Runtime** | Minimum minutes per day the appliance must run. This is a hard constraint -- appliances with unmet min_runtime are protected from shedding. |
-| **Max Daily Runtime** | Maximum minutes per day -- appliance is forced off after this |
+| Field                     | Description                                                                                                                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Min Daily Runtime**     | Minimum minutes per day the appliance must run. This is a hard constraint -- appliances with unmet min_runtime are protected from shedding.                                                                    |
+| **Max Daily Runtime**     | Maximum minutes per day -- appliance is forced off after this                                                                                                                                                  |
 | **Max Daily Activations** | Maximum number of times per day the appliance may be turned on. Leave empty for unlimited. Useful for appliances with limited cycle life (e.g., compressors) or appliances that should not restart frequently. |
-| **Schedule Deadline** | Time by which min runtime must be completed (e.g. `07:00`) |
+| **Schedule Deadline**     | Time by which min runtime must be completed (e.g. `07:00`)                                                                                                                                                     |
 
 The planner uses these constraints to schedule appliances in advance, using cheap tariff windows or forecast solar to meet deadlines.
 
@@ -67,10 +67,10 @@ The planner uses these constraints to schedule appliances in advance, using chea
 
 ## Time Window Constraints
 
-| Field | Description |
-|-------|-------------|
+| Field           | Description                                                              |
+| --------------- | ------------------------------------------------------------------------ |
 | **Start After** | Earliest time of day the appliance is allowed to turn on (e.g., `08:00`) |
-| **End Before** | Latest time of day the appliance is allowed to run (e.g., `20:00`) |
+| **End Before**  | Latest time of day the appliance is allowed to run (e.g., `20:00`)       |
 
 Outside of the configured time window, the optimizer will not turn the appliance on. This is useful for appliances that should only run during daytime hours (e.g., a pool pump) or to avoid running noisy appliances at night.
 
@@ -78,8 +78,8 @@ Outside of the configured time window, the optimizer will not turn the appliance
 
 ## Appliance Dependencies
 
-| Field | Description |
-|-------|-------------|
+| Field                  | Description                                                      |
+| ---------------------- | ---------------------------------------------------------------- |
 | **Requires Appliance** | Another appliance that must be running before this one can start |
 
 Use this to chain appliances. For example, a heat pump circulation pump that should only run when the heat pump itself is running.
@@ -88,8 +88,8 @@ Use this to chain appliances. For example, a heat pump circulation pump that sho
 
 ## Averaging Window
 
-| Field | Description |
-|-------|-------------|
+| Field                | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
 | **Averaging Window** | Custom history window in seconds for excess power averaging (overrides the global default) |
 
 By default, the optimizer averages excess power over a recent history window to smooth sensor noise. Set a custom averaging window per appliance if you need a longer or shorter smoothing period (e.g., a shorter window for fast-reacting appliances like EV chargers).
@@ -106,13 +106,13 @@ Set **Battery Discharge Override** to the maximum watts the battery should disch
 
 ## Advanced Fields
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| **On Only** | Off | Once turned on, never turn off (good for dishwashers mid-cycle) |
-| **Protect From Preemption** | Off | When enabled, this appliance will never be shed to make room for a higher-priority appliance (requires global preemption to be enabled) |
-| **Switch Interval** | 300 s | Minimum seconds between state changes |
-| **Allow Grid Supplement** | Off | Allow a small grid draw to keep the appliance running |
-| **Max Grid Power** | -- | Maximum watts to draw from grid if grid supplement is enabled |
+| Field                       | Default | Description                                                                                                                             |
+| --------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **On Only**                 | Off     | Once turned on, never turn off (good for dishwashers mid-cycle)                                                                         |
+| **Protect From Preemption** | Off     | When enabled, this appliance will never be shed to make room for a higher-priority appliance (requires global preemption to be enabled) |
+| **Switch Interval**         | 300 s   | Minimum seconds between state changes                                                                                                   |
+| **Allow Grid Supplement**   | Off     | Allow a small grid draw to keep the appliance running                                                                                   |
+| **Max Grid Power**          | --      | Maximum watts to draw from grid if grid supplement is enabled                                                                           |
 
 > **Note:** Battery-level protection is configured in the battery settings, not per appliance. The `min_battery_soc` threshold (set during initial setup or in options) causes the optimizer to shed appliances when the battery SoC drops below the configured minimum.
 

--- a/docs/configuration/energy-pricing.md
+++ b/docs/configuration/energy-pricing.md
@@ -6,36 +6,38 @@ The tariff integration enables the optimizer to run appliances during cheap elec
 
 ## Supported Providers
 
-| Provider | HA Integration Required |
-|----------|------------------------|
-| **None** | — Solar excess control only |
-| **Tibber** | [Tibber integration](https://www.home-assistant.io/integrations/tibber/) |
-| **Awattar** | [Awattar integration](https://github.com/mampfes/hacs_awattar) |
-| **Nordpool** | [Nordpool integration](https://github.com/custom-components/nordpool) |
+| Provider           | HA Integration Required                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| **None**           | — Solar excess control only                                                                |
+| **Tibber**         | [Tibber integration](https://www.home-assistant.io/integrations/tibber/)                   |
+| **Awattar**        | [Awattar integration](https://github.com/mampfes/hacs_awattar)                             |
+| **Nordpool**       | [Nordpool integration](https://github.com/custom-components/nordpool)                      |
 | **Octopus Energy** | [Octopus Energy integration](https://github.com/BottlecapDave/HomeAssistant-OctopusEnergy) |
-| **Generic sensor** | Any sensor exposing a numeric price in your local currency per kWh |
+| **Generic sensor** | Any sensor exposing a numeric price in your local currency per kWh                         |
 
 ---
 
 ## Configuration Fields
 
-| Field | Description |
-|-------|-------------|
-| **Cheap Price Threshold** | Prices at or below this value trigger "cheap tariff" mode (e.g. `0.10` €/kWh) |
+| Field                              | Description                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| **Cheap Price Threshold**          | Prices at or below this value trigger "cheap tariff" mode (e.g. `0.10` €/kWh)        |
 | **Battery Charge Price Threshold** | Prices at or below this value allow grid charging of the battery (e.g. `0.08` €/kWh) |
-| **Feed-In Tariff** | Fixed revenue per kWh exported to grid (e.g. `0.07` €/kWh) |
-| **Feed-In Tariff Sensor** | Alternative: a sensor that provides a dynamic feed-in tariff |
+| **Feed-In Tariff**                 | Fixed revenue per kWh exported to grid (e.g. `0.07` €/kWh)                           |
+| **Feed-In Tariff Sensor**          | Alternative: a sensor that provides a dynamic feed-in tariff                         |
 
 ---
 
 ## How Tariff Data Is Used
 
 ### Cheap Tariff Charging
+
 When the current price is below the **Cheap Price Threshold**, the optimizer can run appliances even without solar excess. This is useful for running the dishwasher or topping up the EV battery at off-peak rates overnight.
 
 Each appliance can be configured to participate in cheap tariff windows or not.
 
 ### Opportunity Cost
+
 The integration calculates the net value of using solar power vs. exporting it:
 
 ```
@@ -47,7 +49,9 @@ If `net_savings_per_kwh` is high (e.g. buying at 0.30, selling at 0.07 → 0.23 
 If feed-in tariff is high (e.g. guaranteed 0.20 €/kWh export), the optimizer may prefer to export over running low-priority appliances.
 
 ### Planning
+
 The 24-hour planner uses future tariff windows to schedule appliances optimally:
+
 - Identifies the cheapest hours for must-run tasks (EV charging deadline)
 - Reserves solar excess hours for high-priority appliances
 - Avoids running appliances during expensive peak periods

--- a/docs/configuration/initial-setup.md
+++ b/docs/configuration/initial-setup.md
@@ -8,10 +8,10 @@ This page walks you through the PV Excess Control setup wizard step by step.
 
 Choose the type of inverter in your system:
 
-| Option | When to use |
-|--------|-------------|
-| **Standard** | PV + grid only, no battery storage |
-| **Hybrid** | PV + battery storage (battery steps appear later) |
+| Option       | When to use                                       |
+| ------------ | ------------------------------------------------- |
+| **Standard** | PV + grid only, no battery storage                |
+| **Hybrid**   | PV + battery storage (battery steps appear later) |
 
 Also set **Grid Voltage** (default: 230 V). This is used to convert between amps and watts for dynamic current control.
 
@@ -60,22 +60,22 @@ See [Solar Forecast](solar-forecast.md) for details.
 
 Configure how the battery is managed alongside appliances:
 
-| Strategy | Behavior |
-|----------|----------|
-| **Battery First** | Fills the battery before turning on appliances |
-| **Appliance First** | Runs appliances before charging the battery |
-| **Balanced** | Splits excess proportionally between battery and appliances |
+| Strategy            | Behavior                                                    |
+| ------------------- | ----------------------------------------------------------- |
+| **Battery First**   | Fills the battery before turning on appliances              |
+| **Appliance First** | Runs appliances before charging the battery                 |
+| **Balanced**        | Splits excess proportionally between battery and appliances |
 
 Additional battery settings:
 
-| Field | Description |
-|-------|-------------|
-| **Target SoC** | Desired charge level to reach by target time (e.g. 80%) |
-| **Target Time** | Time by which the battery should reach target SoC (e.g. 07:00) |
-| **Allow Grid Charging** | Allow charging the battery from the grid during cheap tariff periods |
-| **Battery Max Discharge Entity** | Entity to control maximum battery discharge power |
-| **Battery Max Discharge Default** | Default maximum discharge power when no override is active (W) |
-| **Min Battery SoC** | When battery SoC drops below this threshold, all non-essential appliances are shed and battery discharge is blocked. Leave empty to disable. |
+| Field                             | Description                                                                                                                                  |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target SoC**                    | Desired charge level to reach by target time (e.g. 80%)                                                                                      |
+| **Target Time**                   | Time by which the battery should reach target SoC (e.g. 07:00)                                                                               |
+| **Allow Grid Charging**           | Allow charging the battery from the grid during cheap tariff periods                                                                         |
+| **Battery Max Discharge Entity**  | Entity to control maximum battery discharge power                                                                                            |
+| **Battery Max Discharge Default** | Default maximum discharge power when no override is active (W)                                                                               |
+| **Min Battery SoC**               | When battery SoC drops below this threshold, all non-essential appliances are shed and battery discharge is blocked. Leave empty to disable. |
 
 See [Battery Management](../features/battery-management.md) for details.
 
@@ -83,17 +83,17 @@ See [Battery Management](../features/battery-management.md) for details.
 
 ## Step 6 — Global Settings
 
-| Field | Default | Description |
-|-------|---------|-------------|
-| Controller Interval | 30 s | How often the real-time optimizer runs |
-| Planner Interval | 900 s | How often the 24-hour planner recalculates |
-| Plan Influence | Light | How the planner affects decisions: **None** (pure reactive), **Light** (lower thresholds when plan says ON), **Plan follows** (schedule-driven). See [How It Works](../advanced/how-it-works.md#plan-influence) |
-| Enable Preemption | Off | When enabled, the optimizer can shed lower-priority appliances to start higher-priority ones that lack sufficient excess power |
-| Export Limit | — | Maximum grid export in watts (for feed-in capped systems) |
-| Notification Service | — | HA notify service name (e.g. `notify.mobile_app_phone`) |
-| Notify Appliance On | Off | Send a notification when an appliance is turned on |
-| Notify Appliance Off | Off | Send a notification when an appliance is turned off |
-| Notify Daily Summary | Off | Send a daily summary at midnight with energy stats |
+| Field                | Default | Description                                                                                                                                                                                                     |
+| -------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Controller Interval  | 30 s    | How often the real-time optimizer runs                                                                                                                                                                          |
+| Planner Interval     | 900 s   | How often the 24-hour planner recalculates                                                                                                                                                                      |
+| Plan Influence       | Light   | How the planner affects decisions: **None** (pure reactive), **Light** (lower thresholds when plan says ON), **Plan follows** (schedule-driven). See [How It Works](../advanced/how-it-works.md#plan-influence) |
+| Enable Preemption    | Off     | When enabled, the optimizer can shed lower-priority appliances to start higher-priority ones that lack sufficient excess power                                                                                  |
+| Export Limit         | —       | Maximum grid export in watts (for feed-in capped systems)                                                                                                                                                       |
+| Notification Service | —       | HA notify service name (e.g. `notify.mobile_app_phone`)                                                                                                                                                         |
+| Notify Appliance On  | Off     | Send a notification when an appliance is turned on                                                                                                                                                              |
+| Notify Appliance Off | Off     | Send a notification when an appliance is turned off                                                                                                                                                             |
+| Notify Daily Summary | Off     | Send a daily summary at midnight with energy stats                                                                                                                                                              |
 
 ---
 
@@ -134,6 +134,7 @@ Battery strategy: Balanced
 ```
 
 Appliances added:
+
 - EV Charger (priority 10, dynamic current, EV SoC sensor)
 - Heat Pump (priority 20, 2000 W, on-only mode)
 - Dishwasher (priority 50, 1800 W, min runtime 1h)

--- a/docs/configuration/multi-inverter.md
+++ b/docs/configuration/multi-inverter.md
@@ -54,6 +54,7 @@ template:
 ```
 
 In PV Excess Control sensor mapping:
+
 - PV Power: `sensor.combined_pv_power`
 - Import/Export: `sensor.fronius_smart_meter_power`
 

--- a/docs/configuration/sensor-mapping.md
+++ b/docs/configuration/sensor-mapping.md
@@ -6,17 +6,17 @@ The integration needs power sensors from your inverter to calculate excess solar
 
 ## Required vs Optional Sensors
 
-| Sensor | Required? | Description |
-|--------|-----------|-------------|
-| PV Power | If no Import/Export | Power currently produced by the solar panels |
-| Grid Export Power | If no Import/Export | Power being sent to the grid (positive = export) |
-| Import/Export Power | Alternative | Combined grid sensor (positive = export, negative = import) |
-| Load Power | Optional | Total house consumption |
-| Battery SoC | Hybrid only | Battery state of charge (0-100 %) |
-| Battery Power | Hybrid only | Combined battery charge/discharge power (positive = charging) |
-| Battery Charge Power | Hybrid only | Battery charging power (alternative to combined Battery Power) |
-| Battery Discharge Power | Hybrid only | Battery discharging power (alternative to combined Battery Power) |
-| Battery Capacity | Hybrid only | Battery total capacity in kWh |
+| Sensor                  | Required?           | Description                                                       |
+| ----------------------- | ------------------- | ----------------------------------------------------------------- |
+| PV Power                | If no Import/Export | Power currently produced by the solar panels                      |
+| Grid Export Power       | If no Import/Export | Power being sent to the grid (positive = export)                  |
+| Import/Export Power     | Alternative         | Combined grid sensor (positive = export, negative = import)       |
+| Load Power              | Optional            | Total house consumption                                           |
+| Battery SoC             | Hybrid only         | Battery state of charge (0-100 %)                                 |
+| Battery Power           | Hybrid only         | Combined battery charge/discharge power (positive = charging)     |
+| Battery Charge Power    | Hybrid only         | Battery charging power (alternative to combined Battery Power)    |
+| Battery Discharge Power | Hybrid only         | Battery discharging power (alternative to combined Battery Power) |
+| Battery Capacity        | Hybrid only         | Battery total capacity in kWh                                     |
 
 > **Units:** All power sensors can report in **W** or **kW** — the integration reads the sensor's `unit_of_measurement` attribute and converts automatically. No manual conversion needed.
 
@@ -29,18 +29,23 @@ You need **at least one** of: `PV Power + Load Power`, `PV Power + Grid Export`,
 The integration calculates excess power depending on which sensors are configured:
 
 **If Import/Export sensor is provided:**
+
 ```
 excess = grid_export - grid_import
 ```
+
 (The import/export sensor value is split into its import and export components.)
 
 **If Grid Export sensor only:**
+
 ```
 excess = grid_export
 ```
+
 (Falls back to `pv_production - load_power` when export reads zero.)
 
 **If neither (PV + Load only):**
+
 ```
 excess = pv_production - load_power
 ```
@@ -52,41 +57,46 @@ Note: Battery power is **not** added to the excess calculation. The battery's ef
 ## Common Inverter Brands
 
 ### Solis / Ginlong
+
 ```yaml
-PV Power:        sensor.solis_pv_power
-Import/Export:   sensor.solis_grid_import_export  # positive = export
-Battery SoC:     sensor.solis_battery_soc
-Battery Power:   sensor.solis_battery_charge_discharge_power
+PV Power: sensor.solis_pv_power
+Import/Export: sensor.solis_grid_import_export # positive = export
+Battery SoC: sensor.solis_battery_soc
+Battery Power: sensor.solis_battery_charge_discharge_power
 ```
 
 ### SMA
+
 ```yaml
-PV Power:        sensor.sma_total_power
-Grid Export:     sensor.sma_grid_feed_in
-Battery SoC:     sensor.sma_battery_charge_status
-Battery Power:   sensor.sma_battery_power
+PV Power: sensor.sma_total_power
+Grid Export: sensor.sma_grid_feed_in
+Battery SoC: sensor.sma_battery_charge_status
+Battery Power: sensor.sma_battery_power
 ```
 
 ### Fronius
+
 ```yaml
-PV Power:        sensor.fronius_pv_power
-Import/Export:   sensor.fronius_meter_power  # positive = export
-Battery SoC:     sensor.fronius_battery_soc
-Battery Power:   sensor.fronius_battery_power
+PV Power: sensor.fronius_pv_power
+Import/Export: sensor.fronius_meter_power # positive = export
+Battery SoC: sensor.fronius_battery_soc
+Battery Power: sensor.fronius_battery_power
 ```
 
 ### Huawei SUN2000
+
 ```yaml
-PV Power:        sensor.huawei_solar_power
-Import/Export:   sensor.huawei_solar_grid_exported_power  # with sign
-Battery SoC:     sensor.huawei_solar_battery_state_of_capacity
-Battery Power:   sensor.huawei_solar_charge_discharge_power
+PV Power: sensor.huawei_solar_power
+Import/Export: sensor.huawei_solar_grid_exported_power # with sign
+Battery SoC: sensor.huawei_solar_battery_state_of_capacity
+Battery Power: sensor.huawei_solar_charge_discharge_power
 ```
 
 ### Shelly EM (no inverter integration)
+
 ```yaml
-PV Power:        sensor.shelly_em_pv_channel_power
-Import/Export:   sensor.shelly_em_grid_channel_power  # positive = export
+PV Power: sensor.shelly_em_pv_channel_power
+Import/Export: sensor.shelly_em_grid_channel_power # positive = export
 ```
 
 ---
@@ -98,7 +108,7 @@ Different inverters use different sign conventions for grid power. The integrati
 - **Export positive**: Grid Export Power sensor, value is positive when exporting
 - **Export positive, import negative**: Import/Export Power sensor (set this field instead)
 
-> **Migrating from the blueprint?** The original PV Excess Control blueprint used the opposite convention for the combined sensor (*positive = import, negative = export*). The new integration uses **positive = export, negative = import** for Import/Export. If your excess power looks inverted after migration, either negate the sensor with the template below or use the separate **Grid Export Power** field instead.
+> **Migrating from the blueprint?** The original PV Excess Control blueprint used the opposite convention for the combined sensor (_positive = import, negative = export_). The new integration uses **positive = export, negative = import** for Import/Export. If your excess power looks inverted after migration, either negate the sensor with the template below or use the separate **Grid Export Power** field instead.
 
 If your sensor uses the opposite convention (export negative on the export sensor), create a template sensor to invert it:
 

--- a/docs/configuration/solar-forecast.md
+++ b/docs/configuration/solar-forecast.md
@@ -6,12 +6,12 @@ A solar forecast allows the 24-hour planner to schedule appliances intelligently
 
 ## Supported Providers
 
-| Provider | HA Integration |
-|----------|---------------|
-| **None** | No forecast; planner uses fixed averages |
-| **Solcast** | [ha-solcast-solar](https://github.com/BJReplay/ha-solcast-solar) |
+| Provider           | HA Integration                                                                        |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| **None**           | No forecast; planner uses fixed averages                                              |
+| **Solcast**        | [ha-solcast-solar](https://github.com/BJReplay/ha-solcast-solar)                      |
 | **Forecast.Solar** | [Built-in HA integration](https://www.home-assistant.io/integrations/forecast_solar/) |
-| **Generic sensor** | Any sensor exposing remaining-today kWh |
+| **Generic sensor** | Any sensor exposing remaining-today kWh                                               |
 
 ---
 
@@ -33,9 +33,9 @@ When forecast data is available, the 24-hour planner:
 2. Configure your roof segments (azimuth, tilt, peak power)
 3. In PV Excess Control, select **Solcast** and set:
 
-| Field | Example Value |
-|-------|--------------|
-| Forecast sensor | `sensor.solcast_pv_forecast_forecast_remaining_today` |
+| Field                    | Example Value                                             |
+| ------------------------ | --------------------------------------------------------- |
+| Forecast sensor          | `sensor.solcast_pv_forecast_forecast_remaining_today`     |
 | Tomorrow forecast sensor | `sensor.solcast_pv_forecast_forecast_tomorrow` (optional) |
 
 The integration automatically extracts hourly breakdown data from Solcast's attributes.
@@ -50,9 +50,9 @@ The **Tomorrow Forecast Sensor** enables weather pre-planning: if tomorrow's for
 2. Enter your roof parameters
 3. In PV Excess Control, select **Forecast.Solar** and set:
 
-| Field | Example Value |
-|-------|--------------|
-| Forecast sensor | `sensor.energy_production_today_remaining` |
+| Field                    | Example Value                                                         |
+| ------------------------ | --------------------------------------------------------------------- |
+| Forecast sensor          | `sensor.energy_production_today_remaining`                            |
 | Tomorrow forecast sensor | (optional — Forecast.Solar provides this via its own tomorrow sensor) |
 
 ---

--- a/docs/dashboard-examples.md
+++ b/docs/dashboard-examples.md
@@ -12,11 +12,11 @@ This page provides ready-to-use YAML examples for a complete solar excess dashbo
 
 Install the following community cards via **HACS → Frontend** before using these examples.
 
-| Card | HACS Frontend Name | GitHub |
-|------|--------------------|--------|
-| Mushroom Cards | `mushroom` | [piitaya/lovelace-mushroom](https://github.com/piitaya/lovelace-mushroom) |
-| ApexCharts Card | `apexcharts-card` | [RomRider/apexcharts-card](https://github.com/RomRider/apexcharts-card) |
-| Mini Graph Card | `mini-graph-card` | [kalkih/mini-graph-card](https://github.com/kalkih/mini-graph-card) |
+| Card                 | HACS Frontend Name     | GitHub                                                                          |
+| -------------------- | ---------------------- | ------------------------------------------------------------------------------- |
+| Mushroom Cards       | `mushroom`             | [piitaya/lovelace-mushroom](https://github.com/piitaya/lovelace-mushroom)       |
+| ApexCharts Card      | `apexcharts-card`      | [RomRider/apexcharts-card](https://github.com/RomRider/apexcharts-card)         |
+| Mini Graph Card      | `mini-graph-card`      | [kalkih/mini-graph-card](https://github.com/kalkih/mini-graph-card)             |
 | Power Flow Card Plus | `power-flow-card-plus` | [flixlix/power-flow-card-plus](https://github.com/flixlix/power-flow-card-plus) |
 
 After installing each card, **reload your browser** (Ctrl+Shift+R / Cmd+Shift+R) for the cards to be recognized.
@@ -89,16 +89,16 @@ Full animated power flow diagram. Replace the sensor entity IDs with your invert
 type: custom:power-flow-card-plus
 entities:
   grid:
-    entity: sensor.fronius_grid_export    # <- CHANGE
+    entity: sensor.fronius_grid_export # <- CHANGE
     secondary_info:
-      entity: sensor.fronius_grid_import  # <- CHANGE
+      entity: sensor.fronius_grid_import # <- CHANGE
   solar:
-    entity: sensor.fronius_pv_power       # <- CHANGE
+    entity: sensor.fronius_pv_power # <- CHANGE
   battery:
-    entity: sensor.fronius_battery_power  # <- CHANGE
-    state_of_charge: sensor.fronius_battery_soc  # <- CHANGE
+    entity: sensor.fronius_battery_power # <- CHANGE
+    state_of_charge: sensor.fronius_battery_soc # <- CHANGE
   home:
-    entity: sensor.fronius_load_power     # <- CHANGE
+    entity: sensor.fronius_load_power # <- CHANGE
   individual:
     - entity: sensor.pv_excess_control_ev_charger_power
       name: EV Charger
@@ -123,7 +123,7 @@ type: horizontal-stack
 cards:
   - type: custom:mushroom-template-card
     primary: Solar
-    secondary: "{{ states('sensor.fronius_pv_power') | int }} W"  # <- CHANGE
+    secondary: "{{ states('sensor.fronius_pv_power') | int }} W" # <- CHANGE
     icon: mdi:solar-power-variant
     icon_color: >-
       {% if states('sensor.fronius_pv_power') | int > 100 %}amber{% else %}disabled{% endif %}
@@ -136,14 +136,14 @@ cards:
       {% if v > 500 %}green{% elif v > 0 %}amber{% else %}red{% endif %}
   - type: custom:mushroom-template-card
     primary: Battery
-    secondary: "{{ states('sensor.fronius_battery_soc') | int }}%"  # <- CHANGE
+    secondary: "{{ states('sensor.fronius_battery_soc') | int }}%" # <- CHANGE
     icon: mdi:battery
     icon_color: >-
       {% set s = states('sensor.fronius_battery_soc') | int %}
       {% if s > 70 %}green{% elif s > 30 %}amber{% else %}red{% endif %}
   - type: custom:mushroom-template-card
     primary: Grid
-    secondary: "{{ states('sensor.fronius_grid_import') | int }} W"  # <- CHANGE
+    secondary: "{{ states('sensor.fronius_grid_import') | int }} W" # <- CHANGE
     icon: mdi:transmission-tower-import
     icon_color: >-
       {% if states('sensor.fronius_grid_import') | int > 100 %}red{% else %}disabled{% endif %}
@@ -401,7 +401,7 @@ span:
   start: day
 series:
   # Today's forecast — filled area
-  - entity: sensor.solcast_pv_forecast_forecast_today    # <- CHANGE
+  - entity: sensor.solcast_pv_forecast_forecast_today # <- CHANGE
     name: Today
     color: "var(--warning-color)"
     type: area
@@ -418,7 +418,7 @@ series:
         Math.round((item.pv_estimate || item.watts || 0) * 1000)
       ]);
   # Tomorrow's forecast — line only
-  - entity: sensor.solcast_pv_forecast_forecast_tomorrow  # <- CHANGE
+  - entity: sensor.solcast_pv_forecast_forecast_tomorrow # <- CHANGE
     name: Tomorrow
     color: "var(--info-color)"
     type: line
@@ -458,6 +458,7 @@ Overlays electricity prices (columns) with planned appliance activity (color-cod
 This chart uses the `plan_entries` attribute on `sensor.pv_excess_control_plan_confidence`, which includes `appliance_name`, `action`, `reason`, `window_start`, and `window_end` for each planned 15-minute slot.
 
 > **Ready-to-use YAML files:**
+>
 > - [`price-schedule-card-template.yaml`](dashboard/price-schedule-card-template.yaml) — generic template with `# <- CHANGE` markers
 > - [`price-schedule-card-example.yaml`](dashboard/price-schedule-card-example.yaml) — concrete example with 4 appliances and Octopus Energy pricing
 
@@ -754,16 +755,16 @@ cards:
   - type: custom:power-flow-card-plus
     entities:
       grid:
-        entity: sensor.fronius_grid_export         # <- CHANGE
+        entity: sensor.fronius_grid_export # <- CHANGE
         secondary_info:
-          entity: sensor.fronius_grid_import       # <- CHANGE
+          entity: sensor.fronius_grid_import # <- CHANGE
       solar:
-        entity: sensor.fronius_pv_power            # <- CHANGE
+        entity: sensor.fronius_pv_power # <- CHANGE
       battery:
-        entity: sensor.fronius_battery_power       # <- CHANGE
-        state_of_charge: sensor.fronius_battery_soc  # <- CHANGE
+        entity: sensor.fronius_battery_power # <- CHANGE
+        state_of_charge: sensor.fronius_battery_soc # <- CHANGE
       home:
-        entity: sensor.fronius_load_power          # <- CHANGE
+        entity: sensor.fronius_load_power # <- CHANGE
       individual:
         - entity: sensor.pv_excess_control_ev_charger_power
           name: EV Charger
@@ -872,7 +873,7 @@ cards:
     span:
       start: day
     series:
-      - entity: sensor.solcast_pv_forecast_forecast_today    # <- CHANGE
+      - entity: sensor.solcast_pv_forecast_forecast_today # <- CHANGE
         name: Today
         color: "var(--warning-color)"
         type: area
@@ -888,7 +889,7 @@ cards:
             new Date(item.period_start || item.datetime).getTime(),
             Math.round((item.pv_estimate || item.watts || 0) * 1000)
           ]);
-      - entity: sensor.solcast_pv_forecast_forecast_tomorrow  # <- CHANGE
+      - entity: sensor.solcast_pv_forecast_forecast_tomorrow # <- CHANGE
         name: Tomorrow
         color: "var(--info-color)"
         type: line

--- a/docs/dashboard/custom-dashboards.md
+++ b/docs/dashboard/custom-dashboards.md
@@ -8,30 +8,30 @@ This page documents all entities exposed by PV Excess Control and their attribut
 
 ### System-Level Entities
 
-| Entity | Description |
-|--------|-------------|
-| `sensor.pv_excess_control_excess_power` | Current excess power (W) |
-| `sensor.pv_excess_control_plan_confidence` | Plan confidence score |
+| Entity                                             | Description                       |
+| -------------------------------------------------- | --------------------------------- |
+| `sensor.pv_excess_control_excess_power`            | Current excess power (W)          |
+| `sensor.pv_excess_control_plan_confidence`         | Plan confidence score             |
 | `binary_sensor.pv_excess_control_excess_available` | Whether excess power is available |
-| `switch.pv_excess_control_control_enabled` | Master on/off for the integration |
-| `switch.pv_excess_control_force_charge` | Force battery grid charging |
-| `select.pv_excess_control_battery_strategy` | Battery strategy selector |
+| `switch.pv_excess_control_control_enabled`         | Master on/off for the integration |
+| `switch.pv_excess_control_force_charge`            | Force battery grid charging       |
+| `select.pv_excess_control_battery_strategy`        | Battery strategy selector         |
 
 ### Per-Appliance Entities
 
 For an appliance named "Water Heater" (slug: `water_heater`):
 
-| Entity | Description |
-|--------|-------------|
-| `sensor.pv_excess_control_water_heater_power` | Current power draw (W) |
-| `sensor.pv_excess_control_water_heater_runtime_today` | Runtime today |
-| `sensor.pv_excess_control_water_heater_energy_today` | Energy consumed today (kWh) |
-| `sensor.pv_excess_control_water_heater_activations_today` | Number of times turned on today |
-| `sensor.pv_excess_control_water_heater_status` | Current appliance status |
-| `switch.pv_excess_control_water_heater_enabled` | Enable/disable this appliance |
-| `switch.pv_excess_control_water_heater_override` | Manual override toggle |
-| `binary_sensor.pv_excess_control_water_heater_active` | Whether the appliance is currently running |
-| `number.pv_excess_control_water_heater_priority` | Priority setting (1-1000) |
+| Entity                                                    | Description                                |
+| --------------------------------------------------------- | ------------------------------------------ |
+| `sensor.pv_excess_control_water_heater_power`             | Current power draw (W)                     |
+| `sensor.pv_excess_control_water_heater_runtime_today`     | Runtime today                              |
+| `sensor.pv_excess_control_water_heater_energy_today`      | Energy consumed today (kWh)                |
+| `sensor.pv_excess_control_water_heater_activations_today` | Number of times turned on today            |
+| `sensor.pv_excess_control_water_heater_status`            | Current appliance status                   |
+| `switch.pv_excess_control_water_heater_enabled`           | Enable/disable this appliance              |
+| `switch.pv_excess_control_water_heater_override`          | Manual override toggle                     |
+| `binary_sensor.pv_excess_control_water_heater_active`     | Whether the appliance is currently running |
+| `number.pv_excess_control_water_heater_priority`          | Priority setting (1-1000)                  |
 
 ---
 
@@ -40,21 +40,21 @@ For an appliance named "Water Heater" (slug: `water_heater`):
 The `sensor.pv_excess_control_plan_confidence` entity exposes the planner's
 scheduled actions so dashboard cards can visualize them.
 
-| Attribute | Type | Meaning |
-|---|---|---|
-| `plan_entries` | list | All planned actions for the planning horizon. Each entry is a dict (see below). |
-| `plan_entry_count` | int | Total number of plan entries. |
+| Attribute          | Type | Meaning                                                                         |
+| ------------------ | ---- | ------------------------------------------------------------------------------- |
+| `plan_entries`     | list | All planned actions for the planning horizon. Each entry is a dict (see below). |
+| `plan_entry_count` | int  | Total number of plan entries.                                                   |
 
 Each entry in `plan_entries`:
 
-| Field | Type | Meaning |
-|---|---|---|
-| `appliance_id` | string | Internal appliance ID (ULID). |
-| `appliance_name` | string | Human-readable appliance name (as configured). |
-| `action` | string | Planned action: `on`, `off`, `set_current`, or `idle`. |
-| `reason` | string | Why scheduled: `excess_available`, `cheap_tariff`, `min_runtime`, `deadline`, etc. |
-| `window_start` | ISO datetime | Start of the 15-minute planning window (present when a tariff window is assigned). |
-| `window_end` | ISO datetime | End of the 15-minute planning window. |
+| Field            | Type         | Meaning                                                                            |
+| ---------------- | ------------ | ---------------------------------------------------------------------------------- |
+| `appliance_id`   | string       | Internal appliance ID (ULID).                                                      |
+| `appliance_name` | string       | Human-readable appliance name (as configured).                                     |
+| `action`         | string       | Planned action: `on`, `off`, `set_current`, or `idle`.                             |
+| `reason`         | string       | Why scheduled: `excess_available`, `cheap_tariff`, `min_runtime`, `deadline`, etc. |
+| `window_start`   | ISO datetime | Start of the 15-minute planning window (present when a tariff window is assigned). |
+| `window_end`     | ISO datetime | End of the 15-minute planning window.                                              |
 
 ---
 
@@ -116,16 +116,16 @@ structured attributes that make it easy to build richer Lovelace cards
 without parsing the state string. The state string is meant to be a
 human-readable summary; the attributes give you machine-readable values.
 
-| Attribute | Type | Meaning |
-|---|---|---|
-| `action` | string | Machine-readable decision: `on`, `off`, `set_current`, or `idle`. |
-| `overrides_plan` | bool | `true` when the current decision deviates from the planner's schedule. |
-| `cooldown_seconds_remaining` | int or `null` | Seconds until the next switch is allowed. `null` when no cooldown applies. |
-| `switch_deferred` | bool | `true` when the switch interval prevented applying a state change this cycle. |
-| `headroom_watts` | float or `null` | Watts of headroom before SHED, for already-running appliances. `null` otherwise. |
-| `plan_action` | string or `null` | Planner's scheduled action for the current time window. `null` if no plan or no matching entry. |
-| `plan_window_start` | ISO datetime or `null` | Start of the matching planner window. |
-| `plan_window_end` | ISO datetime or `null` | End of the matching planner window. |
+| Attribute                    | Type                   | Meaning                                                                                         |
+| ---------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `action`                     | string                 | Machine-readable decision: `on`, `off`, `set_current`, or `idle`.                               |
+| `overrides_plan`             | bool                   | `true` when the current decision deviates from the planner's schedule.                          |
+| `cooldown_seconds_remaining` | int or `null`          | Seconds until the next switch is allowed. `null` when no cooldown applies.                      |
+| `switch_deferred`            | bool                   | `true` when the switch interval prevented applying a state change this cycle.                   |
+| `headroom_watts`             | float or `null`        | Watts of headroom before SHED, for already-running appliances. `null` otherwise.                |
+| `plan_action`                | string or `null`       | Planner's scheduled action for the current time window. `null` if no plan or no matching entry. |
+| `plan_window_start`          | ISO datetime or `null` | Start of the matching planner window.                                                           |
+| `plan_window_end`            | ISO datetime or `null` | End of the matching planner window.                                                             |
 
 ### Example: cooldown countdown badge
 

--- a/docs/dashboard/price-schedule-card-example.yaml
+++ b/docs/dashboard/price-schedule-card-example.yaml
@@ -56,7 +56,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#FF5733'
+      color: "#FF5733"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -88,7 +88,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33C4FF'
+      color: "#33C4FF"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -120,7 +120,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33FF57'
+      color: "#33FF57"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -152,7 +152,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#C433FF'
+      color: "#C433FF"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -205,7 +205,6 @@
       max: 1
       min: 0
 
-
 # ---------- TOMORROW ----------
 
 - type: custom:apexcharts-card
@@ -243,7 +242,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#FF5733'
+      color: "#FF5733"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -276,7 +275,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33C4FF'
+      color: "#33C4FF"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -309,7 +308,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33FF57'
+      color: "#33FF57"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -342,7 +341,7 @@
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#C433FF'
+      color: "#C433FF"
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];

--- a/docs/dashboard/price-schedule-card-template.yaml
+++ b/docs/dashboard/price-schedule-card-template.yaml
@@ -15,7 +15,8 @@
 #
 #   2. For each appliance, duplicate one of the appliance series blocks and
 #      change:
-#        - name:              your appliance name (as configured in PV Excess Control)
+#        - name:              your appliance name (as configured in PV Excess
+#                             Control)
 #        - color:             a distinct hex color
 #        - const name = '…':  must match the appliance name exactly
 #        - const h = …:       the Y-position (use 0.8, 0.6, 0.4, 0.2, etc.)
@@ -25,10 +26,12 @@
 # Prerequisites:
 #   - apexcharts-card installed via HACS (Frontend)
 #   - PV Excess Control integration with planner enabled
-#   - A tariff provider configured that exposes price windows in sensor attributes
+#   - A tariff provider configured that exposes price windows in sensor
+#     attributes
 #
 # Tariff provider notes:
-#   - Octopus Energy: uses "rates" attribute with "value_inc_vat" field (default)
+#   - Octopus Energy: uses "rates" attribute with "value_inc_vat" field
+#                     (default)
 #   - Tibber:         uses "today" / "tomorrow" attributes with "total" field
 #   - Nordpool:       uses "raw_today" / "raw_tomorrow" with "value" field
 #   - aWATTar:        uses "prices" attribute with "price" field
@@ -59,7 +62,7 @@
     #   - aWATTar:  entity.attributes.prices → field: entry.price
     #   - Generic:  entity.attributes.price_windows → field: entry.price
     #
-    - entity: sensor.YOUR_PRICE_SENSOR                  # <- CHANGE
+    - entity: sensor.YOUR_PRICE_SENSOR # <- CHANGE
       name: Price
       type: column
       yaxis_id: price
@@ -80,16 +83,16 @@
     # ── Appliance 1 ───────────────────────────────────────────────────────
     # Duplicate this block for each appliance. Change name, color, and height.
     - entity: sensor.pv_excess_control_plan_confidence
-      name: My Appliance 1                              # <- CHANGE
+      name: My Appliance 1 # <- CHANGE
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#FF5733'                                   # <- CHANGE color
+      color: "#FF5733" # <- CHANGE color
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
-        const name = 'My Appliance 1';                   // <- CHANGE to match your appliance name
-        const h = 0.8;                                   // <- CHANGE height (0.8, 0.6, 0.4, 0.2, ...)
+        const name = 'My Appliance 1'; // <- CHANGE to match your appliance name
+        const h = 0.8;                // <- CHANGE height (0.8, 0.6, ...)
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         const ms = today.getTime();
@@ -112,16 +115,16 @@
 
     # ── Appliance 2 ───────────────────────────────────────────────────────
     - entity: sensor.pv_excess_control_plan_confidence
-      name: My Appliance 2                              # <- CHANGE
+      name: My Appliance 2 # <- CHANGE
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33C4FF'                                   # <- CHANGE color
+      color: "#33C4FF" # <- CHANGE color
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
-        const name = 'My Appliance 2';                   // <- CHANGE to match your appliance name
-        const h = 0.6;                                   // <- CHANGE height
+        const name = 'My Appliance 2'; // <- CHANGE to match your appliance name
+        const h = 0.6;                 // <- CHANGE height
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         const ms = today.getTime();
@@ -161,14 +164,13 @@
       min: 0
       apex_config:
         title:
-          text: €/kWh                                   # <- CHANGE currency
+          text: €/kWh # <- CHANGE currency
         forceNiceScale: true
     - id: schedules
       show: false
       opposite: true
       max: 1
       min: 0
-
 
 # ---------- TOMORROW ----------
 
@@ -182,7 +184,7 @@
     offset: +1d
   series:
     # ── Electricity price columns ──────────────────────────────────────────
-    - entity: sensor.YOUR_PRICE_SENSOR                  # <- CHANGE
+    - entity: sensor.YOUR_PRICE_SENSOR # <- CHANGE
       name: Price
       type: column
       yaxis_id: price
@@ -203,11 +205,11 @@
 
     # ── Appliance 1 ───────────────────────────────────────────────────────
     - entity: sensor.pv_excess_control_plan_confidence
-      name: My Appliance 1                              # <- CHANGE
+      name: My Appliance 1 # <- CHANGE
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#FF5733'                                   # <- CHANGE color
+      color: "#FF5733" # <- CHANGE color
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -236,11 +238,11 @@
 
     # ── Appliance 2 ───────────────────────────────────────────────────────
     - entity: sensor.pv_excess_control_plan_confidence
-      name: My Appliance 2                              # <- CHANGE
+      name: My Appliance 2 # <- CHANGE
       type: line
       curve: stepline
       stroke_width: 3
-      color: '#33C4FF'                                   # <- CHANGE color
+      color: "#33C4FF" # <- CHANGE color
       yaxis_id: schedules
       data_generator: |
         const entries = entity.attributes.plan_entries || [];
@@ -286,7 +288,7 @@
       min: 0
       apex_config:
         title:
-          text: €/kWh                                   # <- CHANGE currency
+          text: €/kWh # <- CHANGE currency
         forceNiceScale: true
     - id: schedules
       show: false

--- a/docs/features/analytics.md
+++ b/docs/features/analytics.md
@@ -7,10 +7,12 @@ PV Excess Control tracks energy consumption, runtime, savings, and self-consumpt
 ## What Is Tracked
 
 ### Per Appliance
+
 - **Energy today** (kWh) -- Solar and grid energy consumed today
 - **Runtime today** -- Total on-time today
 
 ### System-Wide
+
 - **Self-consumption ratio** (%) -- tracked internally by the coordinator
 - **Savings today** -- tracked internally by the coordinator
 
@@ -29,6 +31,7 @@ net_savings_per_kwh = import_price - feed_in_tariff
 If the appliance is running on cheap grid tariff (not solar), the savings calculation reflects the difference between the cheap rate and the normal import price.
 
 Energy sources are tracked per-appliance:
+
 - `solar` -- Running on solar excess
 - `cheap_tariff` -- Running on cheap grid power
 - `grid` -- Running on normal grid power
@@ -41,13 +44,13 @@ Energy sources are tracked per-appliance:
 
 For an appliance named "Water Heater" (slug: `water_heater`):
 
-| Entity | Description |
-|--------|-------------|
-| `sensor.pv_excess_control_water_heater_power` | Current power draw of this appliance (W) |
-| `sensor.pv_excess_control_water_heater_energy_today` | Energy consumed by this appliance today (kWh) |
-| `sensor.pv_excess_control_water_heater_runtime_today` | Runtime of this appliance today |
-| `sensor.pv_excess_control_water_heater_activations_today` | Number of times turned on today |
-| `sensor.pv_excess_control_water_heater_status` | Optimizer's current decision and the reasoning behind it (see the Dashboard guide for attribute reference) |
+| Entity                                                    | Description                                                                                                |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `sensor.pv_excess_control_water_heater_power`             | Current power draw of this appliance (W)                                                                   |
+| `sensor.pv_excess_control_water_heater_energy_today`      | Energy consumed by this appliance today (kWh)                                                              |
+| `sensor.pv_excess_control_water_heater_runtime_today`     | Runtime of this appliance today                                                                            |
+| `sensor.pv_excess_control_water_heater_activations_today` | Number of times turned on today                                                                            |
+| `sensor.pv_excess_control_water_heater_status`            | Optimizer's current decision and the reasoning behind it (see the Dashboard guide for attribute reference) |
 
 ### System-Level
 
@@ -78,6 +81,7 @@ There is no manual reset service. Daily statistics are managed entirely by the i
 For small systems (balcony PV, 600-800 W), analytics help validate whether the integration is worth the effort:
 
 Typical day:
+
 - Solar produced: 2.1 kWh
 - Self-consumed by appliances: 1.8 kWh (86 % self-consumption)
 - Exported: 0.3 kWh

--- a/docs/features/battery-management.md
+++ b/docs/features/battery-management.md
@@ -9,12 +9,15 @@ PV Excess Control integrates with hybrid inverter systems to make battery-aware 
 Three strategies control how the battery is treated relative to appliances:
 
 ### Battery First
+
 The battery is charged to the target SoC before any appliances are turned on. Best for maximizing self-sufficiency -- the battery is always ready for the evening.
 
 ### Appliance First
+
 Appliances run using solar excess before any power goes to the battery. Best for time-sensitive tasks (EV charging deadline, dishwasher cycle) where you want maximum runtime during solar hours.
 
 ### Balanced
+
 Excess solar is split proportionally between battery charging and appliances. The split is calculated so that both reach their targets at the same time.
 
 ---
@@ -24,6 +27,7 @@ Excess solar is split proportionally between battery charging and appliances. Th
 Set a **Target SoC** (e.g. 80 %) and **Target Time** (e.g. 07:00) to tell the planner when the battery needs to be ready.
 
 The planner uses the forecast to calculate:
+
 1. How much energy is needed to reach the target (`capacity x (target_soc - current_soc) / 100`)
 2. Which hours have sufficient solar excess to charge
 3. Whether grid charging is needed to meet the deadline

--- a/docs/features/dynamic-current.md
+++ b/docs/features/dynamic-current.md
@@ -25,13 +25,13 @@ If excess falls below what the minimum current requires, the charger is turned o
 
 Enable **Dynamic Current** on the appliance:
 
-| Field | Example | Description |
-|-------|---------|-------------|
-| Current Entity | `number.wallbox_charging_current` | Writable number entity |
-| Min Current | `6` | EVSE minimum (usually 6 A) |
-| Max Current | `16` or `32` | EVSE or circuit maximum |
-| Current Step | `1.0` | Resolution of current adjustments (default: 0.1 A). Set to 1.0 for chargers that only accept whole-amp values. |
-| Phases | `3` | 1 or 3 phase |
+| Field          | Example                           | Description                                                                                                    |
+| -------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Current Entity | `number.wallbox_charging_current` | Writable number entity                                                                                         |
+| Min Current    | `6`                               | EVSE minimum (usually 6 A)                                                                                     |
+| Max Current    | `16` or `32`                      | EVSE or circuit maximum                                                                                        |
+| Current Step   | `1.0`                             | Resolution of current adjustments (default: 0.1 A). Set to 1.0 for chargers that only accept whole-amp values. |
+| Phases         | `3`                               | 1 or 3 phase                                                                                                   |
 
 ---
 
@@ -56,12 +56,13 @@ The charger must support IEC 61851 pilot signal current control (almost all mode
 The minimum power needed to charge at minimum current:
 
 | Min Current | 1-phase | 3-phase |
-|-------------|---------|---------|
-| 6 A | 1380 W | 4140 W |
-| 8 A | 1840 W | 5520 W |
-| 10 A | 2300 W | 6900 W |
+| ----------- | ------- | ------- |
+| 6 A         | 1380 W  | 4140 W  |
+| 8 A         | 1840 W  | 5520 W  |
+| 10 A        | 2300 W  | 6900 W  |
 
 If your solar production is typically below these thresholds, consider:
+
 - Setting **Allow Grid Supplement** with a small **Max Grid Power** to bridge the gap
 - Using the **Schedule Deadline** feature to charge during cheap overnight hours instead
 

--- a/docs/features/ev-charging.md
+++ b/docs/features/ev-charging.md
@@ -56,6 +56,7 @@ Configure the target SoC per appliance when adding or editing the EV charger in 
 When a **Schedule Deadline** is set (e.g. `07:00`), the planner guarantees the EV reaches its **Min Daily Runtime** by that time.
 
 The planner:
+
 1. Calculates how much runtime remains to meet the minimum
 2. Finds the cheapest available hours (solar excess or cheap tariff) before the deadline
 3. Schedules charging in those hours
@@ -80,12 +81,14 @@ The optimizer fills higher-priority chargers first and uses remaining excess for
 ## Integration with Common Charger Brands
 
 ### go-eCharger
+
 ```
 Switch Entity:   switch.go_echarger_charging
 Current Entity:  number.go_echarger_max_current
 ```
 
 ### Wallbox Pulsar Plus
+
 ```
 Switch Entity:   switch.wallbox_charging
 Current Entity:  number.wallbox_max_charging_current
@@ -93,6 +96,7 @@ Connected Sensor: binary_sensor.wallbox_status_description  # check state values
 ```
 
 ### OCPP Charger
+
 ```
 Switch Entity:   switch.ocpp_charge_point
 Current Entity:  number.ocpp_charge_limit_amps

--- a/docs/features/export-limiting.md
+++ b/docs/features/export-limiting.md
@@ -42,6 +42,7 @@ The optimizer's Phase 2 (ALLOCATE) adds curtailed power to the excess pool, maki
 System: 10 kW PV, 4 kW export limit, hot water heater (3 kW), pool pump (1 kW)
 
 At 13:00 with 9 kW production and 2 kW load:
+
 - Excess without export limit: 7 kW
 - Export limit allows: 4 kW → curtailed: 3 kW
 - Effective excess for appliances: 7 kW (3 kW curtailed + 4 kW would-be export available)

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -22,11 +22,11 @@ This must be a valid HA notify service. The integration calls it using the stand
 
 The following notification toggles are configurable via the integration's Settings step:
 
-| Toggle | Config Field | Default | When it fires |
-|--------|-------------|---------|--------------|
-| **Appliance On** | `notify_appliance_on` | Off | Every time an appliance is switched on |
-| **Appliance Off** | `notify_appliance_off` | Off | Every time an appliance is switched off |
-| **Daily Summary** | `notify_daily_summary` | Off | Once daily at midnight (00:00) with energy stats and savings |
+| Toggle            | Config Field           | Default | When it fires                                                |
+| ----------------- | ---------------------- | ------- | ------------------------------------------------------------ |
+| **Appliance On**  | `notify_appliance_on`  | Off     | Every time an appliance is switched on                       |
+| **Appliance Off** | `notify_appliance_off` | Off     | Every time an appliance is switched off                      |
+| **Daily Summary** | `notify_daily_summary` | Off     | Once daily at midnight (00:00) with energy stats and savings |
 
 ---
 

--- a/docs/features/tariff-optimization.md
+++ b/docs/features/tariff-optimization.md
@@ -9,6 +9,7 @@ The tariff optimizer runs appliances during the cheapest electricity hours, even
 The optimizer has two tariff-aware modes:
 
 ### 1. Opportunity Cost
+
 When solar excess is available and multiple appliances compete for it, the optimizer factors in the **opportunity cost** of using power vs. exporting it:
 
 ```
@@ -18,6 +19,7 @@ net_savings_per_kwh = import_price - feed_in_tariff
 If net savings are high (e.g. 0.30 import - 0.07 export = 0.23 €/kWh), the optimizer aggressively self-consumes. If the feed-in tariff is high relative to import prices, low-priority appliances may be skipped in favour of exporting.
 
 ### 2. Cheap Tariff Windows
+
 When the current price is below the **Cheap Price Threshold**, the planner can schedule appliances using grid power. This is useful for:
 
 - Overnight EV charging at off-peak rates

--- a/docs/features/weather-preplanning.md
+++ b/docs/features/weather-preplanning.md
@@ -46,6 +46,7 @@ To verify pre-planning is active, check the plan entries in the integration's di
 ## Appliance Priority in Pre-Planning
 
 Pre-planning respects appliance priority. If total cheap hours are limited:
+
 1. Highest-priority appliances with deadlines are scheduled first
 2. Lower-priority appliances fill remaining cheap hours
 3. Appliances without deadlines are not included in pre-planning

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,6 +26,7 @@
 2. Extract the archive and copy the `custom_components/pv_excess_control` folder into your Home Assistant `config/custom_components/` directory.
 
    Your directory structure should look like:
+
    ```
    config/
    └── custom_components/
@@ -60,9 +61,11 @@ See [Initial Setup](configuration/initial-setup.md) for a step-by-step walkthrou
 ## Updating
 
 ### Via HACS
+
 HACS will notify you when a new version is available. Click **Update** and restart Home Assistant.
 
 ### Manual
+
 Overwrite the `custom_components/pv_excess_control` folder with the new version, then restart Home Assistant.
 
 ---

--- a/docs/inverter-grid-charge-setup.md
+++ b/docs/inverter-grid-charge-setup.md
@@ -13,7 +13,7 @@ control cycle (default 30 s) and disengages when:
 - the current price rises above your `battery_charge_price_threshold`, or
 - the battery state of charge reaches your `battery_target_soc`.
 
-The integration tracks whether *it* engaged the inverter, so a manual UI
+The integration tracks whether _it_ engaged the inverter, so a manual UI
 change between cycles is silently re-asserted only if conditions still
 match. The state survives Home Assistant restarts.
 
@@ -21,11 +21,11 @@ match. The state survives Home Assistant restarts.
 
 Three optional triplets:
 
-| Triplet     | Required? | Examples                                              |
-|-------------|-----------|-------------------------------------------------------|
-| Enable cmd  | yes       | `input_select.set_sg_battery_forced_charge_discharge_cmd` + `"Forced charge"` / `"Stop (default)"` |
-| Mode        | optional  | `input_select.set_sg_ems_mode` + `"Forced mode"` / `"Self-consumption mode (default)"` |
-| Power       | optional  | `input_number.set_sg_forced_charge_discharge_power`  |
+| Triplet    | Required? | Examples                                                                                           |
+| ---------- | --------- | -------------------------------------------------------------------------------------------------- |
+| Enable cmd | yes       | `input_select.set_sg_battery_forced_charge_discharge_cmd` + `"Forced charge"` / `"Stop (default)"` |
+| Mode       | optional  | `input_select.set_sg_ems_mode` + `"Forced mode"` / `"Self-consumption mode (default)"`             |
+| Power      | optional  | `input_number.set_sg_forced_charge_discharge_power`                                                |
 
 Engage order: mode → power → enable.
 Disengage order: enable (stop) → mode (revert). Power is left untouched on
@@ -42,16 +42,16 @@ Supported entity domains for **power**: `input_number`, `number`.
 
 ### Sungrow SHx with mkaiser Modbus integration
 
-| Field | Value |
-|---|---|
-| Enable entity | `input_select.set_sg_battery_forced_charge_discharge_cmd` |
-| Engage value | `Forced charge` |
-| Disengage value | `Stop (default)` |
-| Mode entity | `input_select.set_sg_ems_mode` |
-| Mode engage value | `Forced mode` |
-| Mode disengage value | `Self-consumption mode (default)` |
-| Power entity | `input_number.set_sg_forced_charge_discharge_power` |
-| Forced grid-charge power | up to 5000 W (inverter cap on SH5RT-V112 / SH10RT-V112) |
+| Field                    | Value                                                     |
+| ------------------------ | --------------------------------------------------------- |
+| Enable entity            | `input_select.set_sg_battery_forced_charge_discharge_cmd` |
+| Engage value             | `Forced charge`                                           |
+| Disengage value          | `Stop (default)`                                          |
+| Mode entity              | `input_select.set_sg_ems_mode`                            |
+| Mode engage value        | `Forced mode`                                             |
+| Mode disengage value     | `Self-consumption mode (default)`                         |
+| Power entity             | `input_number.set_sg_forced_charge_discharge_power`       |
+| Forced grid-charge power | up to 5000 W (inverter cap on SH5RT-V112 / SH10RT-V112)   |
 
 Tip: ensure `input_number.set_sg_max_soc` is at or above `battery_target_soc`
 in the integration; otherwise the inverter stops accepting forced charge
@@ -61,11 +61,11 @@ before the integration's gate trips.
 
 Some integrations expose a simple toggle entity. Wire only the enable triplet:
 
-| Field | Value |
-|---|---|
-| Enable entity | `switch.battery_force_charge` |
-| Engage value | `on` |
-| Disengage value | `off` |
+| Field           | Value                         |
+| --------------- | ----------------------------- |
+| Enable entity   | `switch.battery_force_charge` |
+| Engage value    | `on`                          |
+| Disengage value | `off`                         |
 
 No mode, no power. Power is controlled by whatever the switch represents.
 
@@ -74,20 +74,20 @@ No mode, no power. Power is controlled by whatever the switch represents.
 Likely shape (untested by the maintainer; please open an issue with your
 working values):
 
-| Field | Value |
-|---|---|
-| Enable entity | `select.solis_storage_mode` |
-| Engage value | `Force Charge` |
-| Disengage value | `Self-Use` |
+| Field           | Value                       |
+| --------------- | --------------------------- |
+| Enable entity   | `select.solis_storage_mode` |
+| Engage value    | `Force Charge`              |
+| Disengage value | `Self-Use`                  |
 
 ### Deye / SunSynk — placeholder, contributions welcome
 
-| Field | Value |
-|---|---|
-| Enable entity | `select.sunsynk_priority_mode` |
-| Engage value | `Battery First` |
-| Disengage value | `Load First` |
-| Power entity | `number.sunsynk_grid_charge_power` |
+| Field           | Value                              |
+| --------------- | ---------------------------------- |
+| Enable entity   | `select.sunsynk_priority_mode`     |
+| Engage value    | `Battery First`                    |
+| Disengage value | `Load First`                       |
+| Power entity    | `number.sunsynk_grid_charge_power` |
 
 ### Generic Modbus via input_number + automation
 
@@ -105,7 +105,7 @@ your `modbus.write_register` calls.
   the inverter's accepted range (e.g. Sungrow 0–5000W).
 - **mkaiser helper-vs-Modbus distinction:** The mkaiser integration writes
   Modbus only via its bundled automations. Always point this integration
-  at the `input_select` / `input_number` *helpers*, never directly at
+  at the `input_select` / `input_number` _helpers_, never directly at
   Modbus.
 - **Test your wiring before relying on it:** Flip the manual `force_charge`
   switch in HA. Watch the inverter's mode change in the UI and verify

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -20,26 +20,26 @@ The original PV Excess Control was a Home Assistant blueprint — an automation 
 
 ### Inverter Setup
 
-| Blueprint Input | New Integration Field | Location |
-|-----------------|----------------------|----------|
-| _(not in blueprint)_ | Inverter Type | Inverter Setup step |
-| _(not in blueprint)_ | Grid Voltage (V) | Inverter Setup step |
+| Blueprint Input      | New Integration Field | Location            |
+| -------------------- | --------------------- | ------------------- |
+| _(not in blueprint)_ | Inverter Type         | Inverter Setup step |
+| _(not in blueprint)_ | Grid Voltage (V)      | Inverter Setup step |
 
 The blueprint assumed a standard inverter. The new integration asks you to specify **Standard** or **Hybrid** (battery-connected) to optimize excess power calculation.
 
 ### Core Power Sensors
 
-| Blueprint Input | New Integration Field | Location |
-|-----------------|----------------------|----------|
-| `pv_power_sensor` | PV Production Power Sensor | Sensor Mapping step |
-| `grid_export_sensor` | Grid Export Power Sensor | Sensor Mapping step |
+| Blueprint Input      | New Integration Field               | Location            |
+| -------------------- | ----------------------------------- | ------------------- |
+| `pv_power_sensor`    | PV Production Power Sensor          | Sensor Mapping step |
+| `grid_export_sensor` | Grid Export Power Sensor            | Sensor Mapping step |
 | _(not in blueprint)_ | Combined Import/Export Power Sensor | Sensor Mapping step |
-| `load_power_sensor` | Load Power Sensor | Sensor Mapping step |
-| `battery_soc_sensor` | Battery State of Charge Sensor | Sensor Mapping step |
-| _(not in blueprint)_ | Combined Battery Power Sensor | Sensor Mapping step |
-| _(not in blueprint)_ | Battery Charge Power Sensor | Sensor Mapping step |
-| _(not in blueprint)_ | Battery Discharge Power Sensor | Sensor Mapping step |
-| _(not in blueprint)_ | Battery Capacity (kWh) | Sensor Mapping step |
+| `load_power_sensor`  | Load Power Sensor                   | Sensor Mapping step |
+| `battery_soc_sensor` | Battery State of Charge Sensor      | Sensor Mapping step |
+| _(not in blueprint)_ | Combined Battery Power Sensor       | Sensor Mapping step |
+| _(not in blueprint)_ | Battery Charge Power Sensor         | Sensor Mapping step |
+| _(not in blueprint)_ | Battery Discharge Power Sensor      | Sensor Mapping step |
+| _(not in blueprint)_ | Battery Capacity (kWh)              | Sensor Mapping step |
 
 > **Note:** All power sensors accept both W and kW — the integration reads the sensor's `unit_of_measurement` and converts automatically.
 
@@ -49,62 +49,62 @@ The blueprint controlled a single appliance. In the new integration, each applia
 
 #### Basic Settings
 
-| Blueprint Input | New Appliance Field | Notes |
-|-----------------|---------------------|-------|
-| `appliance_switch` | Appliance Entity | |
-| `appliance_power` | Nominal Power (W) | |
-| `appliance_priority` | Priority (1-1000) | Same scale: 1 = highest priority |
-| _(not in blueprint)_ | Appliance Name | Friendly name for the appliance |
+| Blueprint Input      | New Appliance Field | Notes                                       |
+| -------------------- | ------------------- | ------------------------------------------- |
+| `appliance_switch`   | Appliance Entity    |                                             |
+| `appliance_power`    | Nominal Power (W)   |                                             |
+| `appliance_priority` | Priority (1-1000)   | Same scale: 1 = highest priority            |
+| _(not in blueprint)_ | Appliance Name      | Friendly name for the appliance             |
 | _(not in blueprint)_ | Actual Power Sensor | Optional real-time power tracking (W or kW) |
-| _(not in blueprint)_ | Number of Phases | Used for amps-to-watts conversion |
+| _(not in blueprint)_ | Number of Phases    | Used for amps-to-watts conversion           |
 
 #### Dynamic Current (EV Chargers)
 
-| Blueprint Input | New Appliance Field | Notes |
-|-----------------|---------------------|-------|
-| `ev_charger_mode` | Dynamic Current | Enable for variable-amp control |
-| `min_charge_current` | Min Current (A) | |
-| `max_charge_current` | Max Current (A) | |
-| _(not in blueprint)_ | Current Step Size (A) | Resolution of amp adjustments (default 0.1 A) |
-| `ev_soc_sensor` | EV SoC Sensor | |
-| `ev_connected_sensor` | EV Connected Sensor | |
-| _(not in blueprint)_ | EV Target SoC | Stop charging at this SoC % |
+| Blueprint Input       | New Appliance Field   | Notes                                         |
+| --------------------- | --------------------- | --------------------------------------------- |
+| `ev_charger_mode`     | Dynamic Current       | Enable for variable-amp control               |
+| `min_charge_current`  | Min Current (A)       |                                               |
+| `max_charge_current`  | Max Current (A)       |                                               |
+| _(not in blueprint)_  | Current Step Size (A) | Resolution of amp adjustments (default 0.1 A) |
+| `ev_soc_sensor`       | EV SoC Sensor         |                                               |
+| `ev_connected_sensor` | EV Connected Sensor   |                                               |
+| _(not in blueprint)_  | EV Target SoC         | Stop charging at this SoC %                   |
 
 #### Constraints & Grid Settings
 
-| Blueprint Input | New Appliance Field | Notes |
-|-----------------|---------------------|-------|
-| `turn_off_delay` | Switch Interval (s) | Renamed, in seconds (default 300 s) |
-| `on_only_mode` | On Only | |
-| `min_daily_runtime` | Min Daily Runtime (min) | Now in minutes |
-| `required_by_time` | Schedule Deadline | |
-| _(not in blueprint)_ | Max Daily Runtime (min) | Hard stop after this many minutes |
-| _(not in blueprint)_ | Max Daily Activations | Limit on/off cycles per day |
-| _(not in blueprint)_ | Activation Buffer (W) | Per-appliance ON threshold (default 200 W standard, 50 W dynamic) |
-| _(not in blueprint)_ | Start After | Earliest time of day to operate |
-| _(not in blueprint)_ | End Before | Latest time of day to operate |
-| _(not in blueprint)_ | Averaging Window (s) | Per-appliance excess smoothing window |
-| _(not in blueprint)_ | Allow Grid Supplement | Use cheap grid power to supplement |
-| _(not in blueprint)_ | Max Grid Power (W) | Limit on grid draw during supplementation |
-| _(not in blueprint)_ | Cheap Price Threshold | Per-appliance price threshold (falls back to global) |
-| _(not in blueprint)_ | Big Consumer | Enable battery discharge protection |
-| _(not in blueprint)_ | Battery Discharge Override (W) | Max discharge when this appliance is active |
-| _(not in blueprint)_ | Protect From Preemption | Prevent shedding by higher-priority appliances |
-| _(not in blueprint)_ | Requires Appliance | Dependency — another appliance must be running first |
-| _(not in blueprint)_ | Run Only as Helper | Only runs when a dependent appliance needs it |
+| Blueprint Input      | New Appliance Field            | Notes                                                             |
+| -------------------- | ------------------------------ | ----------------------------------------------------------------- |
+| `turn_off_delay`     | Switch Interval (s)            | Renamed, in seconds (default 300 s)                               |
+| `on_only_mode`       | On Only                        |                                                                   |
+| `min_daily_runtime`  | Min Daily Runtime (min)        | Now in minutes                                                    |
+| `required_by_time`   | Schedule Deadline              |                                                                   |
+| _(not in blueprint)_ | Max Daily Runtime (min)        | Hard stop after this many minutes                                 |
+| _(not in blueprint)_ | Max Daily Activations          | Limit on/off cycles per day                                       |
+| _(not in blueprint)_ | Activation Buffer (W)          | Per-appliance ON threshold (default 200 W standard, 50 W dynamic) |
+| _(not in blueprint)_ | Start After                    | Earliest time of day to operate                                   |
+| _(not in blueprint)_ | End Before                     | Latest time of day to operate                                     |
+| _(not in blueprint)_ | Averaging Window (s)           | Per-appliance excess smoothing window                             |
+| _(not in blueprint)_ | Allow Grid Supplement          | Use cheap grid power to supplement                                |
+| _(not in blueprint)_ | Max Grid Power (W)             | Limit on grid draw during supplementation                         |
+| _(not in blueprint)_ | Cheap Price Threshold          | Per-appliance price threshold (falls back to global)              |
+| _(not in blueprint)_ | Big Consumer                   | Enable battery discharge protection                               |
+| _(not in blueprint)_ | Battery Discharge Override (W) | Max discharge when this appliance is active                       |
+| _(not in blueprint)_ | Protect From Preemption        | Prevent shedding by higher-priority appliances                    |
+| _(not in blueprint)_ | Requires Appliance             | Dependency — another appliance must be running first              |
+| _(not in blueprint)_ | Run Only as Helper             | Only runs when a dependent appliance needs it                     |
 
 ### Global Settings
 
-| Blueprint Input | New Integration Field | Notes |
-|-----------------|-----------------------|-------|
-| `update_interval` | Controller Update Interval | Renamed (default 30 s) |
-| `excess_threshold` | _(removed)_ | Replaced by per-appliance Activation Buffer |
-| `off_threshold` | Shed Threshold (W) | Now configurable in Global Settings (default -50 W) |
-| _(not in blueprint)_ | Planner Update Interval | How often the planner recalculates (default 900 s) |
-| _(not in blueprint)_ | Export Limit (W) | For feed-in capped systems |
-| _(not in blueprint)_ | Plan Influence Mode | None / Light / Plan Follows |
-| _(not in blueprint)_ | Enable Priority Preemption | Shed lower-priority to start higher-priority |
-| _(not in blueprint)_ | Notification Service | HA notification target |
+| Blueprint Input      | New Integration Field      | Notes                                               |
+| -------------------- | -------------------------- | --------------------------------------------------- |
+| `update_interval`    | Controller Update Interval | Renamed (default 30 s)                              |
+| `excess_threshold`   | _(removed)_                | Replaced by per-appliance Activation Buffer         |
+| `off_threshold`      | Shed Threshold (W)         | Now configurable in Global Settings (default -50 W) |
+| _(not in blueprint)_ | Planner Update Interval    | How often the planner recalculates (default 900 s)  |
+| _(not in blueprint)_ | Export Limit (W)           | For feed-in capped systems                          |
+| _(not in blueprint)_ | Plan Influence Mode        | None / Light / Plan Follows                         |
+| _(not in blueprint)_ | Enable Priority Preemption | Shed lower-priority to start higher-priority        |
+| _(not in blueprint)_ | Notification Service       | HA notification target                              |
 
 ---
 
@@ -144,6 +144,7 @@ Follow [Installation](installation.md). Do not remove the blueprint automation y
 Go to Settings → Devices & Services → Add Integration → PV Excess Control.
 
 The setup wizard has six steps:
+
 1. **Inverter Setup** — inverter type and grid voltage
 2. **Sensor Mapping** — map your power and battery sensors
 3. **Energy Pricing** — tariff provider and price thresholds
@@ -183,4 +184,4 @@ Each blueprint instance becomes one appliance sub-entry. The integration handles
 The new integration supports per-appliance **Activation Buffer** (ON threshold) in each appliance's Constraints step. Set this to match the excess threshold you had in the blueprint. Additionally, you can set a per-appliance **Averaging Window** to control how quickly the appliance reacts to excess changes.
 
 **Combined Import/Export sensor sign convention flipped**
-The original blueprint documented the combined Import/Export sensor as *positive = import, negative = export* (matching how utility meters typically display grid power). The new integration uses the opposite convention: **positive = export, negative = import**. This keeps the sign of the combined sensor consistent with how the integration reasons about excess internally (positive number means surplus). If you reuse the same sensor and the excess calculations look inverted, either create a template sensor that negates the value, or switch to the separate **Grid Export Power** field instead (which only takes positive export watts).
+The original blueprint documented the combined Import/Export sensor as _positive = import, negative = export_ (matching how utility meters typically display grid power). The new integration uses the opposite convention: **positive = export, negative = import**. This keeps the sign of the combined sensor consistent with how the integration reasons about excess internally (positive number means surplus). If you reuse the same sensor and the excess calculations look inverted, either create a template sensor that negates the value, or switch to the separate **Grid Export Power** field instead (which only takes positive export watts).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E4",
+    "E7",
+    "E9",
+    "F",
+    "B",
+    "UP",
+    "SIM",
+    "G",
+]
+
+[tool.codespell]
+skip = 'README.de.md'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,16 @@
 """Shared test fixtures for PV Excess Control tests."""
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.pv_excess_control.models import (
-    Action,
     ApplianceConfig,
-    ApplianceState,
-    BatteryDischargeAction,
-    BatteryStrategy,
-    BatteryTarget,
-    ControlDecision,
-    OptimizerResult,
-    Plan,
     PowerState,
     TariffInfo,
-    TariffWindow,
 )
 
 
@@ -112,19 +104,27 @@ def mock_inverter_controller():
 @pytest.fixture
 def mock_tariff_at():
     """Build a TariffInfo at a given price and threshold."""
-    def _build(current_price, battery_charge_price_threshold=0.02, cheap_price_threshold=0.05, feed_in_tariff=0.08):
+
+    def _build(
+        current_price,
+        battery_charge_price_threshold=0.02,
+        cheap_price_threshold=0.05,
+        feed_in_tariff=0.08,
+    ):
         return TariffInfo(
             current_price=current_price,
             feed_in_tariff=feed_in_tariff,
             cheap_price_threshold=cheap_price_threshold,
             battery_charge_price_threshold=battery_charge_price_threshold,
         )
+
     return _build
 
 
 @pytest.fixture
 def mock_power_state_with_soc():
     """Build a PowerState with the given battery_soc."""
+
     def _build(battery_soc):
         return PowerState(
             pv_production=0.0,
@@ -135,8 +135,9 @@ def mock_power_state_with_soc():
             battery_soc=battery_soc,
             battery_power=None,
             ev_soc=None,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
         )
+
     return _build
 
 
@@ -151,7 +152,6 @@ def coordinator_factory():
         CONF_GRID_EXPORT,
         CONF_GRID_VOLTAGE,
         CONF_LOAD_POWER,
-        CONF_PLAN_INFLUENCE,
         CONF_PLANNER_INTERVAL,
         CONF_PV_POWER,
         CONF_TARIFF_PROVIDER,
@@ -238,7 +238,9 @@ def coordinator_factory():
         coord.appliance_states = {}
         coord.control_decisions = []
         coord.battery_discharge_action = None
-        coord._planner_interval = entry.data.get(CONF_PLANNER_INTERVAL, DEFAULT_PLANNER_INTERVAL)
+        coord._planner_interval = entry.data.get(
+            CONF_PLANNER_INTERVAL, DEFAULT_PLANNER_INTERVAL
+        )
         coord._planner_counter = 0
         coord._startup_time = datetime.now()
         coord._enabled = True
@@ -265,7 +267,9 @@ def coordinator_factory():
 
         coord.analytics = AnalyticsTracker(feed_in_tariff=0.0, normal_import_price=0.25)
         coord.notifications = NotificationManager(
-            hass, notification_settings=None, notification_service=None,
+            hass,
+            notification_settings=None,
+            notification_service=None,
         )
 
         # Grid charge state machine fields
@@ -291,17 +295,22 @@ def freeze_time(monkeypatch):
     """Patches the coordinator module's `_time.monotonic` so the state machine
     sees controllable elapsed time. Returns an object with .tick(seconds: float).
     Use as `with freeze_time() as ft:` then `ft.tick(seconds=N)`."""
+
     class _FT:
         def __init__(self):
             self._t = 1_000_000.0
+
         def __enter__(self):
             monkeypatch.setattr(
                 "custom_components.pv_excess_control.coordinator._time.monotonic",
                 lambda: self._t,
             )
             return self
+
         def __exit__(self, *args):
             return None
+
         def tick(self, seconds: float):
             self._t += seconds
+
     return _FT

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 
-import pytest
 
 from custom_components.pv_excess_control.analytics import (
     AnalyticsTracker,
@@ -108,7 +107,7 @@ class TestAnalyticsTracker:
     def test_multiple_appliances_independent_stats(self):
         """Each appliance accumulates its own independent statistics."""
         tracker = AnalyticsTracker(feed_in_tariff=0.0, normal_import_price=0.25)
-        tracker.record_cycle("ev", 7000, 3600, "solar", 0.25)   # 7kWh
+        tracker.record_cycle("ev", 7000, 3600, "solar", 0.25)  # 7kWh
         tracker.record_cycle("heatpump", 2000, 1800, "solar", 0.25)  # 1kWh
 
         ev_stats = tracker.get_appliance_stats("ev")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,10 +4,10 @@ Uses unittest.mock to simulate the Home Assistant config flow machinery.
 Tests verify that each step collects the right data, validates inputs,
 shows conditional fields, and that the full flow creates a correct entry.
 """
+
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 import voluptuous as vol
@@ -38,14 +38,19 @@ from custom_components.pv_excess_control.const import (
     CONF_PRICE_SENSOR,
     CONF_PV_POWER,
     CONF_TARIFF_PROVIDER,
-    DEFAULT_CONTROLLER_INTERVAL,
-    DEFAULT_GRID_VOLTAGE,
-    DEFAULT_PLANNER_INTERVAL,
     DOMAIN,
     BatteryStrategy,
     ForecastProvider,
     InverterType,
     TariffProvider,
+    CONF_AUTO_BATTERY_GRID_CHARGE,
+    CONF_BATTERY_GRID_CHARGE_POWER_W,
+    CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY,
+    CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE,
+    CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE,
+    CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY,
+    CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE,
+    CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE,
 )
 from custom_components.pv_excess_control.config_flow import (
     PvExcessControlConfigFlow,
@@ -479,7 +484,10 @@ class TestStepForecast:
 
         assert result["step_id"] == "settings"
         assert flow.data[CONF_FORECAST_PROVIDER] == ForecastProvider.SOLCAST
-        assert flow.data[CONF_FORECAST_SENSOR] == "sensor.solcast_pv_forecast_forecast_remaining_today"
+        assert (
+            flow.data[CONF_FORECAST_SENSOR]
+            == "sensor.solcast_pv_forecast_forecast_remaining_today"
+        )
 
     @pytest.mark.asyncio
     async def test_step_forecast_generic_requires_sensor(self):
@@ -493,9 +501,7 @@ class TestStepForecast:
 
         assert result["type"] == "form"
         assert result["step_id"] == "forecast"
-        assert (
-            result["errors"][CONF_FORECAST_SENSOR] == "missing_forecast_sensor"
-        )
+        assert result["errors"][CONF_FORECAST_SENSOR] == "missing_forecast_sensor"
 
     @pytest.mark.asyncio
     async def test_step_forecast_generic_with_sensor(self):
@@ -574,7 +580,9 @@ class TestStepBattery:
         )
 
         assert result["step_id"] == "settings"
-        assert flow.data[CONF_BATTERY_MAX_DISCHARGE_ENTITY] == "number.battery_discharge"
+        assert (
+            flow.data[CONF_BATTERY_MAX_DISCHARGE_ENTITY] == "number.battery_discharge"
+        )
         assert flow.data[CONF_BATTERY_MAX_DISCHARGE_DEFAULT] == 5000
 
     @pytest.mark.asyncio
@@ -975,8 +983,7 @@ class TestSchemaHelpers:
         """Standard schema does not include battery fields."""
         schema = _sensor_schema(is_hybrid=False)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_PV_POWER in key_names
         assert CONF_GRID_EXPORT in key_names
@@ -990,8 +997,7 @@ class TestSchemaHelpers:
         """Hybrid schema includes battery fields."""
         schema = _sensor_schema(is_hybrid=True)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_PV_POWER in key_names
         assert CONF_BATTERY_SOC in key_names
@@ -1002,8 +1008,7 @@ class TestSchemaHelpers:
         """None provider schema has tariff_provider, thresholds, and feed_in_tariff."""
         schema = _energy_schema(TariffProvider.NONE)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_TARIFF_PROVIDER in key_names
         assert CONF_FEED_IN_TARIFF in key_names
@@ -1017,8 +1022,7 @@ class TestSchemaHelpers:
         """Generic provider schema includes price sensor and thresholds."""
         schema = _energy_schema(TariffProvider.GENERIC)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_TARIFF_PROVIDER in key_names
         assert CONF_PRICE_SENSOR in key_names
@@ -1030,8 +1034,7 @@ class TestSchemaHelpers:
         """Tibber provider schema has thresholds and price sensor."""
         schema = _energy_schema(TariffProvider.TIBBER)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_TARIFF_PROVIDER in key_names
         assert CONF_PRICE_SENSOR in key_names
@@ -1041,8 +1044,7 @@ class TestSchemaHelpers:
         """None forecast schema has provider but no sensor."""
         schema = _forecast_schema(ForecastProvider.NONE)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_FORECAST_PROVIDER in key_names
         assert CONF_FORECAST_SENSOR not in key_names
@@ -1051,8 +1053,7 @@ class TestSchemaHelpers:
         """Generic forecast schema has provider and sensor."""
         schema = _forecast_schema(ForecastProvider.GENERIC)
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in schema.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in schema.schema
         ]
         assert CONF_FORECAST_PROVIDER in key_names
         assert CONF_FORECAST_SENSOR in key_names
@@ -1060,8 +1061,7 @@ class TestSchemaHelpers:
     def test_battery_schema_keys(self):
         """Battery schema has all expected keys."""
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in BATTERY_SCHEMA.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in BATTERY_SCHEMA.schema
         ]
         assert CONF_BATTERY_STRATEGY in key_names
         assert CONF_BATTERY_TARGET_SOC in key_names
@@ -1073,8 +1073,7 @@ class TestSchemaHelpers:
     def test_settings_schema_keys(self):
         """Settings schema has all expected keys."""
         key_names = [
-            k.schema if isinstance(k, vol.Marker) else k
-            for k in SETTINGS_SCHEMA.schema
+            k.schema if isinstance(k, vol.Marker) else k for k in SETTINGS_SCHEMA.schema
         ]
         assert CONF_EXPORT_LIMIT in key_names
         assert CONF_CONTROLLER_INTERVAL in key_names
@@ -1189,20 +1188,12 @@ class TestDataAccumulation:
 # Tests for _validate_battery_section
 # ---------------------------------------------------------------------------
 
-from custom_components.pv_excess_control.const import (
-    CONF_AUTO_BATTERY_GRID_CHARGE,
-    CONF_BATTERY_GRID_CHARGE_POWER_W,
-    CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY,
-    CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE,
-    CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE,
-    CONF_INVERTER_FORCE_CHARGE_MODE_ENTITY,
-    CONF_INVERTER_FORCE_CHARGE_MODE_ENGAGE_VALUE,
-    CONF_INVERTER_FORCE_CHARGE_MODE_DISENGAGE_VALUE,
-)
-
 
 def test_auto_battery_grid_charge_requires_enable_entity_and_power_w():
-    from custom_components.pv_excess_control.config_flow import _validate_battery_section
+    from custom_components.pv_excess_control.config_flow import (
+        _validate_battery_section,
+    )
+
     bad = {
         CONF_AUTO_BATTERY_GRID_CHARGE: True,
         # missing CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY
@@ -1213,7 +1204,10 @@ def test_auto_battery_grid_charge_requires_enable_entity_and_power_w():
 
 
 def test_inverter_force_charge_engage_value_required_when_entity_set():
-    from custom_components.pv_excess_control.config_flow import _validate_battery_section
+    from custom_components.pv_excess_control.config_flow import (
+        _validate_battery_section,
+    )
+
     bad = {
         CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY: "input_select.cmd",
         # missing engage/disengage values
@@ -1223,7 +1217,10 @@ def test_inverter_force_charge_engage_value_required_when_entity_set():
 
 
 def test_inverter_force_charge_mode_values_required_when_mode_entity_set():
-    from custom_components.pv_excess_control.config_flow import _validate_battery_section
+    from custom_components.pv_excess_control.config_flow import (
+        _validate_battery_section,
+    )
+
     bad = {
         CONF_INVERTER_FORCE_CHARGE_ENABLE_ENTITY: "input_select.cmd",
         CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE: "Forced charge",
@@ -1236,7 +1233,10 @@ def test_inverter_force_charge_mode_values_required_when_mode_entity_set():
 
 
 def test_validate_battery_section_passes_for_complete_three_step_config():
-    from custom_components.pv_excess_control.config_flow import _validate_battery_section
+    from custom_components.pv_excess_control.config_flow import (
+        _validate_battery_section,
+    )
+
     good = {
         CONF_AUTO_BATTERY_GRID_CHARGE: True,
         CONF_BATTERY_GRID_CHARGE_POWER_W: 5000.0,

--- a/tests/test_config_flow_subentry.py
+++ b/tests/test_config_flow_subentry.py
@@ -5,6 +5,7 @@ version, we mock the subentry base class methods (async_show_form,
 async_create_entry, _get_reconfigure_subentry) and test the flow handler
 directly.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -38,7 +39,6 @@ from custom_components.pv_excess_control.const import (
     CONF_SCHEDULE_DEADLINE,
     CONF_SWITCH_INTERVAL,
     DEFAULT_SWITCH_INTERVAL,
-    DOMAIN,
 )
 from custom_components.pv_excess_control.config_flow import (
     ApplianceSubentryFlowHandler,
@@ -686,9 +686,7 @@ class TestFullFlow:
         flow = _make_subentry_flow()
 
         await flow.async_step_user(user_input=dict(VALID_BASIC_INPUT))
-        await flow.async_step_current(
-            user_input=dict(VALID_CURRENT_INPUT_DISABLED)
-        )
+        await flow.async_step_current(user_input=dict(VALID_CURRENT_INPUT_DISABLED))
         result = await flow.async_step_constraints(
             user_input=dict(VALID_CONSTRAINTS_INPUT)
         )
@@ -732,9 +730,15 @@ class TestReconfigure:
         # Mock HA reconfigure methods
         mock_entry = MagicMock()
         flow._get_entry = MagicMock(return_value=mock_entry)
+
         def mock_update_and_abort(entry, subentry, **kwargs):
-            return {"type": "abort", "reason": "reconfigure_successful",
-                    "title": kwargs.get("title", ""), "data": kwargs.get("data", {})}
+            return {
+                "type": "abort",
+                "reason": "reconfigure_successful",
+                "title": kwargs.get("title", ""),
+                "data": kwargs.get("data", {}),
+            }
+
         flow.async_update_and_abort = MagicMock(side_effect=mock_update_and_abort)
         return flow
 
@@ -987,16 +991,17 @@ class TestEdgeCases:
         flow = _make_subentry_flow()
 
         await flow.async_step_user(user_input=dict(VALID_BASIC_INPUT))
-        await flow.async_step_current(
-            user_input=dict(VALID_CURRENT_INPUT_DISABLED)
-        )
+        await flow.async_step_current(user_input=dict(VALID_CURRENT_INPUT_DISABLED))
         result = await flow.async_step_constraints(
             user_input=dict(VALID_CONSTRAINTS_INPUT)
         )
 
         data = result["data"]
         # Optional fields should not cause errors when absent
-        assert data.get(CONF_ACTUAL_POWER_ENTITY) is None or CONF_ACTUAL_POWER_ENTITY in data
+        assert (
+            data.get(CONF_ACTUAL_POWER_ENTITY) is None
+            or CONF_ACTUAL_POWER_ENTITY in data
+        )
         assert data.get(CONF_EV_SOC_ENTITY) is None or CONF_EV_SOC_ENTITY not in data
 
     @pytest.mark.asyncio
@@ -1073,9 +1078,7 @@ class TestEdgeCases:
                 CONF_PHASES: "1",
             }
         )
-        await flow.async_step_current(
-            user_input={CONF_DYNAMIC_CURRENT: False}
-        )
+        await flow.async_step_current(user_input={CONF_DYNAMIC_CURRENT: False})
         # First submit triggers big consumer warning (3000W >= threshold)
         result = await flow.async_step_constraints(
             user_input=dict(VALID_CONSTRAINTS_INPUT)
@@ -1101,7 +1104,9 @@ class TestCheapGridTargetCurrent:
     @pytest.mark.asyncio
     async def test_cheap_grid_target_current_accepted_for_dynamic_appliance(self):
         """A dynamic-current appliance subentry accepts cheap_grid_target_current."""
-        from custom_components.pv_excess_control.const import CONF_CHEAP_GRID_TARGET_CURRENT
+        from custom_components.pv_excess_control.const import (
+            CONF_CHEAP_GRID_TARGET_CURRENT,
+        )
 
         flow = _make_subentry_flow()
         flow._data = dict(VALID_BASIC_INPUT)
@@ -1120,7 +1125,9 @@ class TestCheapGridTargetCurrent:
     @pytest.mark.asyncio
     async def test_cheap_grid_target_current_rejected_for_non_dynamic_appliance(self):
         """Setting cheap_grid_target_current on a non-dynamic appliance fails validation."""
-        from custom_components.pv_excess_control.const import CONF_CHEAP_GRID_TARGET_CURRENT
+        from custom_components.pv_excess_control.const import (
+            CONF_CHEAP_GRID_TARGET_CURRENT,
+        )
 
         flow = _make_subentry_flow()
         flow._data = dict(VALID_BASIC_INPUT)

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,7 +1,8 @@
 """Tests for PV Excess Control controller module."""
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -18,7 +19,6 @@ from custom_components.pv_excess_control.controller import Controller
 from custom_components.pv_excess_control.models import (
     Action,
     ApplianceConfig,
-    ApplianceState,
     BatteryDischargeAction,
     ControlDecision,
     PowerState,
@@ -29,8 +29,9 @@ from custom_components.pv_excess_control.models import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _utcnow() -> datetime:
-    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
 
 
 def _make_appliance_config(**kwargs) -> ApplianceConfig:
@@ -63,7 +64,9 @@ def _make_appliance_config(**kwargs) -> ApplianceConfig:
     return ApplianceConfig(**defaults)
 
 
-def _make_state(entity_id: str, state_value: str, attributes: dict | None = None) -> MagicMock:
+def _make_state(
+    entity_id: str, state_value: str, attributes: dict | None = None
+) -> MagicMock:
     """Create a mock HA state object."""
     mock_state = MagicMock()
     mock_state.state = state_value
@@ -93,6 +96,7 @@ def _make_hass(states_map: dict[str, MagicMock] | None = None) -> MagicMock:
 # ---------------------------------------------------------------------------
 # TestCollectPowerState
 # ---------------------------------------------------------------------------
+
 
 class TestCollectPowerState:
     def test_collect_power_state(self):
@@ -209,19 +213,23 @@ class TestCollectPowerState:
         """Power sensors reporting in kW are converted to watts."""
         states_map = {
             "sensor.pv_power": _make_state(
-                "sensor.pv_power", "9.9",
+                "sensor.pv_power",
+                "9.9",
                 attributes={"unit_of_measurement": "kW"},
             ),
             "sensor.grid_export": _make_state(
-                "sensor.grid_export", "4.8",
+                "sensor.grid_export",
+                "4.8",
                 attributes={"unit_of_measurement": "kW"},
             ),
             "sensor.load_power": _make_state(
-                "sensor.load_power", "5.1",
+                "sensor.load_power",
+                "5.1",
                 attributes={"unit_of_measurement": "kW"},
             ),
             "sensor.battery_power": _make_state(
-                "sensor.battery_power", "0.5",
+                "sensor.battery_power",
+                "0.5",
                 attributes={"unit_of_measurement": "kW"},
             ),
         }
@@ -244,11 +252,13 @@ class TestCollectPowerState:
         """Power sensors already in W are not modified."""
         states_map = {
             "sensor.pv_power": _make_state(
-                "sensor.pv_power", "5000.0",
+                "sensor.pv_power",
+                "5000.0",
                 attributes={"unit_of_measurement": "W"},
             ),
             "sensor.grid_export": _make_state(
-                "sensor.grid_export", "1200.0",
+                "sensor.grid_export",
+                "1200.0",
                 attributes={"unit_of_measurement": "W"},
             ),
         }
@@ -280,6 +290,7 @@ class TestCollectPowerState:
 # TestCollectApplianceStates
 # ---------------------------------------------------------------------------
 
+
 class TestCollectApplianceStates:
     def test_collect_appliance_states_on(self):
         """Reads on state and actual power from entity."""
@@ -289,9 +300,11 @@ class TestCollectApplianceStates:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            actual_power_entity="sensor.wm_power",
-        )]
+        configs = [
+            _make_appliance_config(
+                actual_power_entity="sensor.wm_power",
+            )
+        ]
         runtime_tracker = {"appliance_1": timedelta(hours=1, minutes=30)}
         result = controller.collect_appliance_states(configs, runtime_tracker)
 
@@ -307,17 +320,20 @@ class TestCollectApplianceStates:
         states_map = {
             "switch.tesla_charge": _make_state("switch.tesla_charge", "on"),
             "sensor.twc_total_power": _make_state(
-                "sensor.twc_total_power", "5.07",
+                "sensor.twc_total_power",
+                "5.07",
                 attributes={"unit_of_measurement": "kW"},
             ),
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="tesla",
-            entity_id="switch.tesla_charge",
-            actual_power_entity="sensor.twc_total_power",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="tesla",
+                entity_id="switch.tesla_charge",
+                actual_power_entity="sensor.twc_total_power",
+            )
+        ]
         result = controller.collect_appliance_states(configs, {})
 
         state = result[0]
@@ -343,18 +359,22 @@ class TestCollectApplianceStates:
         """Reads EV connected binary sensor."""
         states_map = {
             "switch.ev_charger": _make_state("switch.ev_charger", "on"),
-            "binary_sensor.ev_connected": _make_state("binary_sensor.ev_connected", "on"),
+            "binary_sensor.ev_connected": _make_state(
+                "binary_sensor.ev_connected", "on"
+            ),
             "number.ev_current": _make_state("number.ev_current", "10"),
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="ev_charger",
-            entity_id="switch.ev_charger",
-            ev_connected_entity="binary_sensor.ev_connected",
-            current_entity="number.ev_current",
-            dynamic_current=True,
-        )]
+        configs = [
+            _make_appliance_config(
+                id="ev_charger",
+                entity_id="switch.ev_charger",
+                ev_connected_entity="binary_sensor.ev_connected",
+                current_entity="number.ev_current",
+                dynamic_current=True,
+            )
+        ]
         result = controller.collect_appliance_states(configs, {})
 
         assert result[0].ev_connected is True
@@ -364,15 +384,19 @@ class TestCollectApplianceStates:
         """Reads EV disconnected binary sensor."""
         states_map = {
             "switch.ev_charger": _make_state("switch.ev_charger", "off"),
-            "binary_sensor.ev_connected": _make_state("binary_sensor.ev_connected", "off"),
+            "binary_sensor.ev_connected": _make_state(
+                "binary_sensor.ev_connected", "off"
+            ),
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="ev_charger",
-            entity_id="switch.ev_charger",
-            ev_connected_entity="binary_sensor.ev_connected",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="ev_charger",
+                entity_id="switch.ev_charger",
+                ev_connected_entity="binary_sensor.ev_connected",
+            )
+        ]
         result = controller.collect_appliance_states(configs, {})
 
         assert result[0].ev_connected is False
@@ -391,6 +415,7 @@ class TestCollectApplianceStates:
 # ---------------------------------------------------------------------------
 # TestApplyDecisions
 # ---------------------------------------------------------------------------
+
 
 class TestApplyDecisions:
     @pytest.mark.asyncio
@@ -456,10 +481,12 @@ class TestApplyDecisions:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="heat_pump",
-            entity_id="climate.heat_pump",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="heat_pump",
+                entity_id="climate.heat_pump",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="heat_pump",
@@ -485,12 +512,14 @@ class TestApplyDecisions:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="ev_charger",
-            entity_id="switch.ev_charger",
-            dynamic_current=True,
-            current_entity="number.ev_current",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="ev_charger",
+                entity_id="switch.ev_charger",
+                dynamic_current=True,
+                current_entity="number.ev_current",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="ev_charger",
@@ -506,7 +535,8 @@ class TestApplyDecisions:
         assert len(applied) == 1
         assert applied[0]["action"] == Action.SET_CURRENT
         hass.services.async_call.assert_any_call(
-            "number", "set_value",
+            "number",
+            "set_value",
             {"entity_id": "number.ev_current", "value": 10.0},
         )
 
@@ -584,10 +614,12 @@ class TestApplyDecisions:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="toggle_1",
-            entity_id="input_boolean.my_toggle",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="toggle_1",
+                entity_id="input_boolean.my_toggle",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="toggle_1",
@@ -613,10 +645,12 @@ class TestApplyDecisions:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="light_1",
-            entity_id="light.my_light",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="light_1",
+                entity_id="light.my_light",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="light_1",
@@ -642,10 +676,12 @@ class TestApplyDecisions:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="boiler_1",
-            entity_id="water_heater.boiler",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="boiler_1",
+                entity_id="water_heater.boiler",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="boiler_1",
@@ -667,6 +703,7 @@ class TestApplyDecisions:
 # ---------------------------------------------------------------------------
 # TestSwitchInterval
 # ---------------------------------------------------------------------------
+
 
 class TestSwitchInterval:
     @pytest.mark.asyncio
@@ -708,8 +745,8 @@ class TestSwitchInterval:
         config = _make_appliance_config(switch_interval=300)
 
         # Simulate a state change long ago
-        controller._last_state_change["appliance_1"] = (
-            datetime.now() - timedelta(seconds=600)
+        controller._last_state_change["appliance_1"] = datetime.now() - timedelta(
+            seconds=600
         )
 
         decisions = [
@@ -754,6 +791,7 @@ class TestSwitchInterval:
 # ---------------------------------------------------------------------------
 # TestOnOnlyPreventsOff
 # ---------------------------------------------------------------------------
+
 
 class TestOnOnly:
     @pytest.mark.asyncio
@@ -808,6 +846,7 @@ class TestOnOnly:
 # ---------------------------------------------------------------------------
 # TestFiresEvent
 # ---------------------------------------------------------------------------
+
 
 class TestFiresEvent:
     @pytest.mark.asyncio
@@ -896,6 +935,7 @@ class TestFiresEvent:
 # TestBatteryDischargeLimit
 # ---------------------------------------------------------------------------
 
+
 class TestBatteryDischargeLimit:
     @pytest.mark.asyncio
     async def test_battery_discharge_limit_set(self):
@@ -911,7 +951,8 @@ class TestBatteryDischargeLimit:
         )
 
         hass.services.async_call.assert_called_once_with(
-            "number", "set_value",
+            "number",
+            "set_value",
             {"entity_id": "number.battery_max_discharge", "value": 500.0},
         )
 
@@ -929,7 +970,8 @@ class TestBatteryDischargeLimit:
         )
 
         hass.services.async_call.assert_called_once_with(
-            "number", "set_value",
+            "number",
+            "set_value",
             {"entity_id": "number.battery_max_discharge", "value": 5000.0},
         )
 
@@ -967,6 +1009,7 @@ class TestBatteryDischargeLimit:
 # ---------------------------------------------------------------------------
 # TestSensorHelpers
 # ---------------------------------------------------------------------------
+
 
 class TestSensorHelpers:
     def test_read_sensor_valid(self):
@@ -1047,7 +1090,9 @@ class TestSensorHelpers:
     def test_read_binary_unavailable(self):
         """Returns None for unavailable binary sensor."""
         states_map = {
-            "binary_sensor.connected": _make_state("binary_sensor.connected", "unavailable"),
+            "binary_sensor.connected": _make_state(
+                "binary_sensor.connected", "unavailable"
+            ),
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
@@ -1073,6 +1118,7 @@ class TestSensorHelpers:
 # TestCanChangeState
 # ---------------------------------------------------------------------------
 
+
 class TestCanChangeState:
     def test_can_change_no_previous(self):
         """Can change state when no previous change recorded."""
@@ -1096,8 +1142,8 @@ class TestCanChangeState:
         hass = _make_hass()
         controller = Controller(hass, {})
         config = _make_appliance_config(switch_interval=300)
-        controller._last_state_change["appliance_1"] = (
-            datetime.now() - timedelta(seconds=600)
+        controller._last_state_change["appliance_1"] = datetime.now() - timedelta(
+            seconds=600
         )
 
         assert controller._can_change_state(config) is True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,7 @@
 
 Uses the same mock-coordinator helper pattern as test_init.py.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -20,7 +21,10 @@ from custom_components.pv_excess_control.const import (
 
 @pytest.mark.asyncio
 async def test_grid_charge_engages_when_price_below_threshold_and_soc_below_target(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -34,11 +38,14 @@ async def test_grid_charge_engages_when_price_below_threshold_and_soc_below_targ
         },
         inverter_ctl=mock_inverter_controller,
     )
-    coordinator._latest_tariff = mock_tariff_at(current_price=0.01, battery_charge_price_threshold=0.02)
+    coordinator._latest_tariff = mock_tariff_at(
+        current_price=0.01, battery_charge_price_threshold=0.02
+    )
     coordinator._latest_power_state = mock_power_state_with_soc(battery_soc=70.0)
 
     await coordinator._run_grid_charge_state_machine(
-        coordinator._latest_tariff, coordinator._latest_power_state,
+        coordinator._latest_tariff,
+        coordinator._latest_power_state,
     )
 
     mock_inverter_controller.engage.assert_awaited_once_with(5000.0)
@@ -47,7 +54,10 @@ async def test_grid_charge_engages_when_price_below_threshold_and_soc_below_targ
 
 @pytest.mark.asyncio
 async def test_grid_charge_does_not_re_engage_while_already_engaged(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -63,15 +73,21 @@ async def test_grid_charge_does_not_re_engage_while_already_engaged(
     coordinator._latest_tariff = mock_tariff_at(0.01, 0.02)
     coordinator._latest_power_state = mock_power_state_with_soc(70.0)
 
-    await coordinator._run_grid_charge_state_machine(coordinator._latest_tariff, coordinator._latest_power_state)
-    await coordinator._run_grid_charge_state_machine(coordinator._latest_tariff, coordinator._latest_power_state)
+    await coordinator._run_grid_charge_state_machine(
+        coordinator._latest_tariff, coordinator._latest_power_state
+    )
+    await coordinator._run_grid_charge_state_machine(
+        coordinator._latest_tariff, coordinator._latest_power_state
+    )
 
     assert mock_inverter_controller.engage.await_count == 1
 
 
 @pytest.mark.asyncio
 async def test_grid_charge_no_inverter_configured_no_calls(
-    coordinator_factory, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -84,14 +100,20 @@ async def test_grid_charge_no_inverter_configured_no_calls(
     coordinator._latest_power_state = mock_power_state_with_soc(70.0)
 
     # Must not raise
-    await coordinator._run_grid_charge_state_machine(coordinator._latest_tariff, coordinator._latest_power_state)
+    await coordinator._run_grid_charge_state_machine(
+        coordinator._latest_tariff, coordinator._latest_power_state
+    )
 
     assert coordinator._grid_charge_engaged is False
 
 
 @pytest.mark.asyncio
 async def test_grid_charge_disengages_when_price_rises_above_threshold(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc, freeze_time,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
+    freeze_time,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -109,12 +131,14 @@ async def test_grid_charge_disengages_when_price_rises_above_threshold(
     with freeze_time() as ft:
         # Engage
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.01, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.01, 0.02),
+            mock_power_state_with_soc(70.0),
         )
         ft.tick(seconds=6 * 60)  # past hysteresis
         # Price rises
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.10, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.10, 0.02),
+            mock_power_state_with_soc(70.0),
         )
 
     mock_inverter_controller.disengage.assert_awaited_once()
@@ -123,7 +147,11 @@ async def test_grid_charge_disengages_when_price_rises_above_threshold(
 
 @pytest.mark.asyncio
 async def test_grid_charge_disengages_when_soc_reaches_target(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc, freeze_time,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
+    freeze_time,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -139,18 +167,24 @@ async def test_grid_charge_disengages_when_soc_reaches_target(
     )
     with freeze_time() as ft:
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.01, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.01, 0.02),
+            mock_power_state_with_soc(70.0),
         )
         ft.tick(seconds=6 * 60)
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.01, 0.02), mock_power_state_with_soc(100.0),
+            mock_tariff_at(0.01, 0.02),
+            mock_power_state_with_soc(100.0),
         )
     mock_inverter_controller.disengage.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_grid_charge_hysteresis_holds_disengage_for_min_duration(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc, freeze_time,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
+    freeze_time,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -166,11 +200,13 @@ async def test_grid_charge_hysteresis_holds_disengage_for_min_duration(
     )
     with freeze_time() as ft:
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.01, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.01, 0.02),
+            mock_power_state_with_soc(70.0),
         )
         ft.tick(seconds=2 * 60)  # within hysteresis
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.10, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.10, 0.02),
+            mock_power_state_with_soc(70.0),
         )
     mock_inverter_controller.disengage.assert_not_awaited()
     assert coordinator._grid_charge_engaged is True
@@ -178,7 +214,10 @@ async def test_grid_charge_hysteresis_holds_disengage_for_min_duration(
 
 @pytest.mark.asyncio
 async def test_grid_charge_force_charge_switch_bypasses_price_gate(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -203,7 +242,11 @@ async def test_grid_charge_force_charge_switch_bypasses_price_gate(
 
 @pytest.mark.asyncio
 async def test_grid_charge_force_charge_off_bypasses_hysteresis(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc, freeze_time,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
+    freeze_time,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -220,13 +263,15 @@ async def test_grid_charge_force_charge_off_bypasses_hysteresis(
     coordinator._force_charge_prev = False
     with freeze_time() as ft:
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.50, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.50, 0.02),
+            mock_power_state_with_soc(70.0),
         )
         ft.tick(seconds=60)  # well within hysteresis
         # User flips off
         coordinator.force_charge = False
         await coordinator._run_grid_charge_state_machine(
-            mock_tariff_at(0.50, 0.02), mock_power_state_with_soc(70.0),
+            mock_tariff_at(0.50, 0.02),
+            mock_power_state_with_soc(70.0),
         )
     mock_inverter_controller.disengage.assert_awaited_once()
     assert coordinator._grid_charge_engaged is False
@@ -234,7 +279,11 @@ async def test_grid_charge_force_charge_off_bypasses_hysteresis(
 
 @pytest.mark.asyncio
 async def test_grid_charge_state_persisted_across_restart_disengages_when_conditions_clear(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc, freeze_time,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
+    freeze_time,
 ):
     """Persisted engaged=True, fresh restart, conditions cleared → disengage."""
     coordinator = coordinator_factory(
@@ -251,7 +300,7 @@ async def test_grid_charge_state_persisted_across_restart_disengages_when_condit
         inverter_ctl=mock_inverter_controller,
     )
     # Fresh restart: engage_ts is None, so elapsed = monotonic() - 0 ≈ huge → past hysteresis
-    with freeze_time() as ft:
+    with freeze_time():
         await coordinator._run_grid_charge_state_machine(
             mock_tariff_at(0.10, 0.02),  # not cheap
             mock_power_state_with_soc(70.0),
@@ -264,7 +313,10 @@ async def test_grid_charge_state_persisted_across_restart_disengages_when_condit
 @pytest.mark.parametrize("strategy", ["balanced", "battery_first", "appliance_first"])
 async def test_grid_charge_independent_of_battery_strategy(
     strategy,
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     coordinator = coordinator_factory(
         config_data={
@@ -279,6 +331,7 @@ async def test_grid_charge_independent_of_battery_strategy(
         inverter_ctl=mock_inverter_controller,
     )
     await coordinator._run_grid_charge_state_machine(
-        mock_tariff_at(0.01, 0.02), mock_power_state_with_soc(70.0),
+        mock_tariff_at(0.01, 0.02),
+        mock_power_state_with_soc(70.0),
     )
     mock_inverter_controller.engage.assert_awaited_once()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,9 @@ from __future__ import annotations
 
 import pytest
 
+from custom_components.pv_excess_control.coordinator import (
+    _history_size_for_interval,
+)
 from custom_components.pv_excess_control.const import (
     CONF_AUTO_BATTERY_GRID_CHARGE,
     CONF_BATTERY_GRID_CHARGE_POWER_W,
@@ -17,6 +20,22 @@ from custom_components.pv_excess_control.const import (
     CONF_INVERTER_FORCE_CHARGE_ENABLE_ENGAGE_VALUE,
     CONF_INVERTER_FORCE_CHARGE_ENABLE_DISENGAGE_VALUE,
 )
+
+
+@pytest.mark.parametrize(
+    ("controller_interval", "expected_size"),
+    [
+        (15, 120),
+        (30, 60),
+        (60, 30),
+    ],
+)
+def test_history_size_tracks_controller_interval(
+    controller_interval,
+    expected_size,
+):
+    """History must always cover the full 30-minute averaging window."""
+    assert _history_size_for_interval(controller_interval) == expected_size
 
 
 @pytest.mark.asyncio

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -6,9 +6,10 @@ Covers edge cases not already tested in module-specific test files:
 3. Controller: unknown entity domain in apply_decisions
 4. Notifications: rate limit boundary (exactly at the limit)
 """
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -48,10 +49,12 @@ from custom_components.pv_excess_control.planner import Planner
 
 def _dt(hour: int, minute: int = 0) -> datetime:
     """Create a UTC datetime on 2026-03-23 at the given hour:minute."""
-    return datetime(2026, 3, 23, hour, minute, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 23, hour, minute, 0, tzinfo=UTC)
 
 
-def _make_tariff_window(start_hour: int, end_hour: int, price: float, is_cheap: bool = False) -> TariffWindow:
+def _make_tariff_window(
+    start_hour: int, end_hour: int, price: float, is_cheap: bool = False
+) -> TariffWindow:
     return TariffWindow(
         start=_dt(start_hour),
         end=_dt(end_hour),
@@ -107,7 +110,9 @@ def _make_hass(states_map: dict | None = None) -> MagicMock:
     return hass
 
 
-def _make_notification_manager(settings: dict | None = None) -> tuple[MagicMock, NotificationManager]:
+def _make_notification_manager(
+    settings: dict | None = None,
+) -> tuple[MagicMock, NotificationManager]:
     hass = MagicMock()
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
@@ -280,8 +285,15 @@ class TestEnergyProviderEdgeCases:
                 "state": "0.25",
                 "attributes": {
                     "price_windows": [
-                        {"start": "bad_date", "end": "also_bad", "price": 0.25},  # invalid dates
-                        {"start": "2026-03-23T10:00:00+00:00", "end": "2026-03-23T11:00:00+00:00"},  # missing price
+                        {
+                            "start": "bad_date",
+                            "end": "also_bad",
+                            "price": 0.25,
+                        },  # invalid dates
+                        {
+                            "start": "2026-03-23T10:00:00+00:00",
+                            "end": "2026-03-23T11:00:00+00:00",
+                        },  # missing price
                         None,  # None entry
                     ]
                 },
@@ -312,14 +324,17 @@ class TestEnergyProviderEdgeCases:
     def test_tibber_malformed_entries_skipped(self):
         """Tibber entries with missing keys are silently skipped."""
         provider = TibberProvider("sensor.tibber")
-        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.tibber": {
                 "state": "0.15",
                 "attributes": {
                     "today": [
                         {"total": 0.15},  # missing "startsAt"
-                        {"startsAt": now.isoformat(), "total": "not_a_number"},  # bad total
+                        {
+                            "startsAt": now.isoformat(),
+                            "total": "not_a_number",
+                        },  # bad total
                         {"startsAt": now.isoformat(), "total": 0.12},  # valid
                     ],
                     "tomorrow": [],
@@ -336,14 +351,17 @@ class TestEnergyProviderEdgeCases:
     def test_awattar_malformed_prices_skipped(self):
         """Awattar entries with missing keys are silently skipped."""
         provider = AwattarProvider("sensor.awattar")
-        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.awattar": {
                 "state": "5.5",
                 "attributes": {
                     "prices": [
                         {"price_ct_per_kwh": 5.5},  # missing start/end times
-                        {"start_time": now.isoformat(), "end_time": "bad"},  # bad end time
+                        {
+                            "start_time": now.isoformat(),
+                            "end_time": "bad",
+                        },  # bad end time
                         {
                             "start_time": now.isoformat(),
                             "end_time": (now + timedelta(hours=1)).isoformat(),
@@ -382,14 +400,18 @@ class TestEnergyProviderEdgeCases:
     def test_octopus_malformed_rates_skipped(self):
         """Octopus entries with missing keys are silently skipped."""
         provider = OctopusProvider("sensor.octopus")
-        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.octopus": {
                 "state": "0.30",
                 "attributes": {
                     "rates": [
                         {"value_inc_vat": 0.30},  # missing start/end
-                        {"start": now.isoformat(), "end": "garbage", "value_inc_vat": 0.28},  # bad end
+                        {
+                            "start": now.isoformat(),
+                            "end": "garbage",
+                            "value_inc_vat": 0.28,
+                        },  # bad end
                         {
                             "start": now.isoformat(),
                             "end": (now + timedelta(minutes=30)).isoformat(),
@@ -431,10 +453,12 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="media_app",
-            entity_id="media_player.lounge",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="media_app",
+                entity_id="media_player.lounge",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="media_app",
@@ -445,7 +469,7 @@ class TestControllerEdgeCases:
             ),
         ]
 
-        applied = await controller.apply_decisions(decisions, configs)
+        await controller.apply_decisions(decisions, configs)
 
         # Applied tracks that we attempted the state change, but _turn_on does nothing
         # for unknown domains. The decision is still "applied" (logged) but no service called.
@@ -459,10 +483,12 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="auto_1",
-            entity_id="automation.my_auto",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="auto_1",
+                entity_id="automation.my_auto",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="auto_1",
@@ -485,11 +511,13 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="boiler",
-            entity_id="switch.boiler",
-            on_only=True,
-        )]
+        configs = [
+            _make_appliance_config(
+                id="boiler",
+                entity_id="switch.boiler",
+                on_only=True,
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="boiler",
@@ -514,11 +542,15 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            switch_interval=3600,  # 1 hour interval
-        )]
+        configs = [
+            _make_appliance_config(
+                switch_interval=3600,  # 1 hour interval
+            )
+        ]
         # Simulate recent state change
-        controller._last_state_change["appliance_1"] = datetime.now() - timedelta(seconds=10)
+        controller._last_state_change["appliance_1"] = datetime.now() - timedelta(
+            seconds=10
+        )
 
         decisions = [
             ControlDecision(
@@ -544,10 +576,12 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="pool_light",
-            entity_id="light.pool_heater_indicator",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="pool_light",
+                entity_id="light.pool_heater_indicator",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="pool_light",
@@ -573,10 +607,12 @@ class TestControllerEdgeCases:
         }
         hass = _make_hass(states_map)
         controller = Controller(hass, {})
-        configs = [_make_appliance_config(
-            id="water_heater_1",
-            entity_id="water_heater.boiler",
-        )]
+        configs = [
+            _make_appliance_config(
+                id="water_heater_1",
+                entity_id="water_heater.boiler",
+            )
+        ]
         decisions = [
             ControlDecision(
                 appliance_id="water_heater_1",
@@ -627,8 +663,8 @@ class TestNotificationEdgeCases:
         hass, manager = _make_notification_manager(settings)
 
         # 299 seconds ago = still within 300s rate limit
-        manager._last_sent[NotificationEvent.APPLIANCE_ON] = (
-            datetime.now() - timedelta(seconds=299)
+        manager._last_sent[NotificationEvent.APPLIANCE_ON] = datetime.now() - timedelta(
+            seconds=299
         )
 
         result = await manager.async_notify(NotificationEvent.APPLIANCE_ON, "test")
@@ -643,8 +679,8 @@ class TestNotificationEdgeCases:
         hass, manager = _make_notification_manager(settings)
 
         # 301 seconds ago = past the 300s rate limit
-        manager._last_sent[NotificationEvent.APPLIANCE_ON] = (
-            datetime.now() - timedelta(seconds=301)
+        manager._last_sent[NotificationEvent.APPLIANCE_ON] = datetime.now() - timedelta(
+            seconds=301
         )
 
         result = await manager.async_notify(NotificationEvent.APPLIANCE_ON, "test")
@@ -665,7 +701,9 @@ class TestNotificationEdgeCases:
         await manager.async_notify(NotificationEvent.APPLIANCE_ON, "Appliance on")
 
         # APPLIANCE_OFF should not be rate-limited by the APPLIANCE_ON send
-        result = await manager.async_notify(NotificationEvent.APPLIANCE_OFF, "Appliance off")
+        result = await manager.async_notify(
+            NotificationEvent.APPLIANCE_OFF, "Appliance off"
+        )
 
         assert result is True
         assert hass.services.async_call.await_count == 2
@@ -677,11 +715,15 @@ class TestNotificationEdgeCases:
         hass, manager = _make_notification_manager(settings)
 
         # First send
-        first = await manager.async_notify(NotificationEvent.SENSOR_UNAVAILABLE, "msg 1")
+        first = await manager.async_notify(
+            NotificationEvent.SENSOR_UNAVAILABLE, "msg 1"
+        )
         assert first is True
 
         # Immediately after: rate-limited
-        second = await manager.async_notify(NotificationEvent.SENSOR_UNAVAILABLE, "msg 2")
+        second = await manager.async_notify(
+            NotificationEvent.SENSOR_UNAVAILABLE, "msg 2"
+        )
         assert second is False
 
         # Simulate window expiry
@@ -690,7 +732,9 @@ class TestNotificationEdgeCases:
         )
 
         # Should now be allowed
-        third = await manager.async_notify(NotificationEvent.SENSOR_UNAVAILABLE, "msg 3")
+        third = await manager.async_notify(
+            NotificationEvent.SENSOR_UNAVAILABLE, "msg 3"
+        )
         assert third is True
         assert hass.services.async_call.await_count == 2  # first + third
 
@@ -702,7 +746,9 @@ class TestNotificationEdgeCases:
 
         assert NotificationEvent.DAILY_SUMMARY not in manager._last_sent
 
-        result = await manager.async_notify(NotificationEvent.DAILY_SUMMARY, "Daily summary")
+        result = await manager.async_notify(
+            NotificationEvent.DAILY_SUMMARY, "Daily summary"
+        )
 
         assert result is True
         assert NotificationEvent.DAILY_SUMMARY in manager._last_sent

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -1,7 +1,8 @@
 """Tests for the energy module (tariff providers). TDD."""
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
@@ -14,15 +15,18 @@ from custom_components.pv_excess_control.energy import (
     TibberProvider,
     create_tariff_provider,
 )
-from custom_components.pv_excess_control.const import TariffProvider as TariffProviderEnum
+from custom_components.pv_excess_control.const import (
+    TariffProvider as TariffProviderEnum,
+)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _utcnow() -> datetime:
-    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
 
 
 def _hour_later(dt: datetime) -> datetime:
@@ -32,6 +36,7 @@ def _hour_later(dt: datetime) -> datetime:
 # ---------------------------------------------------------------------------
 # TestGenericProvider
 # ---------------------------------------------------------------------------
+
 
 class TestGenericProvider:
     def test_reads_current_price_from_state(self):
@@ -88,8 +93,16 @@ class TestGenericProvider:
                 "state": "0.30",
                 "attributes": {
                     "price_windows": [
-                        {"start": now.isoformat(), "end": later.isoformat(), "price": 0.30},
-                        {"start": later.isoformat(), "end": _hour_later(later).isoformat(), "price": 0.10},
+                        {
+                            "start": now.isoformat(),
+                            "end": later.isoformat(),
+                            "price": 0.30,
+                        },
+                        {
+                            "start": later.isoformat(),
+                            "end": _hour_later(later).isoformat(),
+                            "price": 0.10,
+                        },
                     ]
                 },
             }
@@ -98,7 +111,7 @@ class TestGenericProvider:
         assert len(info.windows) == 2
         assert info.windows[0].price == pytest.approx(0.30)
         assert info.windows[1].price == pytest.approx(0.10)
-        assert info.windows[1].is_cheap is True   # 0.10 < threshold 0.20
+        assert info.windows[1].is_cheap is True  # 0.10 < threshold 0.20
         assert info.windows[0].is_cheap is False  # 0.30 > threshold 0.20
 
     def test_is_abstract_base(self):
@@ -131,6 +144,7 @@ class TestGenericProvider:
 # ---------------------------------------------------------------------------
 # TestTibberProvider
 # ---------------------------------------------------------------------------
+
 
 class TestTibberProvider:
     def test_reads_price_and_windows(self):
@@ -233,6 +247,7 @@ class TestTibberProvider:
 # TestAwattarProvider
 # ---------------------------------------------------------------------------
 
+
 class TestAwattarProvider:
     def test_reads_prices_in_cents(self):
         """AwattarProvider converts cents to euros."""
@@ -314,6 +329,7 @@ class TestAwattarProvider:
 # TestNordpoolProvider
 # ---------------------------------------------------------------------------
 
+
 class TestNordpoolProvider:
     def test_reads_prices(self):
         """NordpoolProvider reads current and hourly prices."""
@@ -358,7 +374,7 @@ class TestNordpoolProvider:
             },
         }
         info = provider.get_tariff_info(states, 0.10, 0.05, 0.0)
-        assert info.windows[0].is_cheap is True   # 0.05 < 0.10
+        assert info.windows[0].is_cheap is True  # 0.05 < 0.10
         assert info.windows[1].is_cheap is False  # 0.15 > 0.10
 
     def test_tomorrow_windows_included(self):
@@ -408,6 +424,7 @@ class TestNordpoolProvider:
 # TestOctopusProvider
 # ---------------------------------------------------------------------------
 
+
 class TestOctopusProvider:
     def test_reads_rates(self):
         """OctopusProvider reads tariff rates."""
@@ -439,8 +456,16 @@ class TestOctopusProvider:
                 "state": "0.20",
                 "attributes": {
                     "rates": [
-                        {"start": now.isoformat(), "end": _hour_later(now).isoformat(), "value_inc_vat": 0.20},
-                        {"start": _hour_later(now).isoformat(), "end": _hour_later(_hour_later(now)).isoformat(), "value_inc_vat": 0.08},
+                        {
+                            "start": now.isoformat(),
+                            "end": _hour_later(now).isoformat(),
+                            "value_inc_vat": 0.20,
+                        },
+                        {
+                            "start": _hour_later(now).isoformat(),
+                            "end": _hour_later(_hour_later(now)).isoformat(),
+                            "value_inc_vat": 0.08,
+                        },
                     ],
                 },
             },
@@ -448,7 +473,7 @@ class TestOctopusProvider:
         info = provider.get_tariff_info(states, 0.15, 0.05, 0.0)
         assert len(info.windows) == 2
         assert info.windows[0].is_cheap is False  # 0.20 > 0.15
-        assert info.windows[1].is_cheap is True   # 0.08 < 0.15
+        assert info.windows[1].is_cheap is True  # 0.08 < 0.15
 
     def test_no_rates_gives_empty_windows(self):
         """If no rates attribute, windows is empty."""
@@ -482,9 +507,11 @@ class TestOctopusProvider:
 # TestCreateTariffProvider (factory)
 # ---------------------------------------------------------------------------
 
+
 class TestCreateTariffProvider:
     def test_create_generic(self):
         from custom_components.pv_excess_control.energy import GenericTariffProvider
+
         p = create_tariff_provider(TariffProviderEnum.GENERIC, "sensor.price")
         assert isinstance(p, GenericTariffProvider)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2,17 +2,16 @@
 
 Covers: switch.py, number.py, binary_sensor.py, select.py
 """
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timedelta, UTC
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.pv_excess_control.const import (
     BatteryStrategy,
-    DOMAIN,
-    MANUFACTURER,
     MAX_PRIORITY,
     MIN_PRIORITY,
 )
@@ -22,6 +21,7 @@ from custom_components.pv_excess_control.models import ApplianceState, PowerStat
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_coordinator(
     enabled: bool = True,
@@ -44,8 +44,12 @@ def _make_coordinator(
     coord.force_charge = force_charge
     coord.battery_strategy = battery_strategy
     coord.appliance_enabled = appliance_enabled if appliance_enabled is not None else {}
-    coord.appliance_overrides = appliance_overrides if appliance_overrides is not None else {}
-    coord.appliance_priorities = appliance_priorities if appliance_priorities is not None else {}
+    coord.appliance_overrides = (
+        appliance_overrides if appliance_overrides is not None else {}
+    )
+    coord.appliance_priorities = (
+        appliance_priorities if appliance_priorities is not None else {}
+    )
     coord.appliance_min_daily_runtime = (
         appliance_min_daily_runtime if appliance_min_daily_runtime is not None else {}
     )
@@ -74,7 +78,7 @@ def _make_power_state(excess_power: float = 0.0) -> PowerState:
         battery_soc=None,
         battery_power=None,
         ev_soc=None,
-        timestamp=datetime(2026, 3, 23, 12, 0, 0, tzinfo=timezone.utc),
+        timestamp=datetime(2026, 3, 23, 12, 0, 0, tzinfo=UTC),
     )
 
 
@@ -94,6 +98,7 @@ def _make_appliance_state(appliance_id: str, is_on: bool = False) -> ApplianceSt
 # ---------------------------------------------------------------------------
 # Switch entity tests
 # ---------------------------------------------------------------------------
+
 
 class TestSwitchEntities:
     """Tests for switch.py entities."""
@@ -261,13 +266,20 @@ class TestSwitchEntities:
         coord = _make_coordinator()
         assert ControlEnabledSwitch(coord).unique_id == "test_entry_id_control_enabled"
         assert ForceChargeSwitch(coord).unique_id == "test_entry_id_force_charge"
-        assert ApplianceEnabledSwitch(coord, "a1", "X").unique_id == "test_entry_id_a1_enabled"
-        assert ApplianceOverrideSwitch(coord, "a1", "X").unique_id == "test_entry_id_a1_override"
+        assert (
+            ApplianceEnabledSwitch(coord, "a1", "X").unique_id
+            == "test_entry_id_a1_enabled"
+        )
+        assert (
+            ApplianceOverrideSwitch(coord, "a1", "X").unique_id
+            == "test_entry_id_a1_override"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Number entity tests
 # ---------------------------------------------------------------------------
+
 
 class TestNumberEntities:
     """Tests for number.py entities."""
@@ -865,15 +877,21 @@ class TestNumberEntities:
         async def _fake_update(entry, sub, *, data):
             sub.data = data
 
-        num.hass.config_entries.async_update_subentry = AsyncMock(side_effect=_fake_update)
+        num.hass.config_entries.async_update_subentry = AsyncMock(
+            side_effect=_fake_update
+        )
 
         await num.async_set_native_value(60.0)
 
         # Called twice: once for min sibling, once for max self
         assert num.hass.config_entries.async_update_subentry.await_count == 2
         # The two calls, in order: min first, then max
-        min_call_kwargs = num.hass.config_entries.async_update_subentry.call_args_list[0].kwargs
-        max_call_kwargs = num.hass.config_entries.async_update_subentry.call_args_list[1].kwargs
+        min_call_kwargs = num.hass.config_entries.async_update_subentry.call_args_list[
+            0
+        ].kwargs
+        max_call_kwargs = num.hass.config_entries.async_update_subentry.call_args_list[
+            1
+        ].kwargs
         assert min_call_kwargs["data"]["min_daily_runtime"] == 60
         # Second call must carry the already-lowered min (guards against a
         # bug where the max persist reads stale subentry.data).
@@ -891,6 +909,7 @@ class TestNumberEntities:
         )
 
         added: list = []
+
         def _add(entities, update_before_add=False):
             added.extend(entities)
 
@@ -916,6 +935,7 @@ class TestNumberEntities:
 # ---------------------------------------------------------------------------
 # Binary sensor entity tests
 # ---------------------------------------------------------------------------
+
 
 class TestBinarySensorEntities:
     """Tests for binary_sensor.py entities."""
@@ -1023,6 +1043,7 @@ class TestBinarySensorEntities:
 # ---------------------------------------------------------------------------
 # Select entity tests
 # ---------------------------------------------------------------------------
+
 
 class TestSelectEntities:
     """Tests for select.py entities."""

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,7 +1,8 @@
 """Tests for the forecast provider module."""
+
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timezone, UTC
 
 import pytest
 
@@ -17,6 +18,7 @@ from custom_components.pv_excess_control.models import ForecastData, HourlyForec
 # ---------------------------------------------------------------------------
 # TestGenericForecastProvider
 # ---------------------------------------------------------------------------
+
 
 class TestGenericForecastProvider:
     def test_reads_remaining_kwh(self):
@@ -78,18 +80,22 @@ class TestGenericForecastProvider:
 # TestSolcastProvider
 # ---------------------------------------------------------------------------
 
+
 class TestSolcastProvider:
     def test_reads_forecast_with_breakdown(self):
         """SolcastProvider reads remaining kWh and hourly breakdown."""
         provider = SolcastProvider("sensor.solcast_remaining")
-        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.solcast_remaining": {
                 "state": "15.2",
                 "attributes": {
                     "forecasts": [
                         {"period_start": now.isoformat(), "pv_estimate": 2.5},
-                        {"period_start": now.replace(minute=30).isoformat(), "pv_estimate": 3.0},
+                        {
+                            "period_start": now.replace(minute=30).isoformat(),
+                            "pv_estimate": 3.0,
+                        },
                     ],
                     "forecast_tomorrow": 18.5,
                 },
@@ -103,14 +109,17 @@ class TestSolcastProvider:
     def test_two_half_hour_slots_combine_into_one_hour(self):
         """Two 30-min Solcast slots for the same hour merge into one HourlyForecast."""
         provider = SolcastProvider("sensor.solcast_remaining")
-        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=UTC)
         states = {
             "sensor.solcast_remaining": {
                 "state": "10.0",
                 "attributes": {
                     "forecasts": [
                         {"period_start": now.isoformat(), "pv_estimate": 2.0},
-                        {"period_start": now.replace(minute=30).isoformat(), "pv_estimate": 2.0},
+                        {
+                            "period_start": now.replace(minute=30).isoformat(),
+                            "pv_estimate": 2.0,
+                        },
                     ],
                     "forecast_tomorrow": None,
                 },
@@ -138,7 +147,9 @@ class TestSolcastProvider:
 
     def test_unavailable_returns_zero(self):
         provider = SolcastProvider("sensor.solcast_remaining")
-        states = {"sensor.solcast_remaining": {"state": "unavailable", "attributes": {}}}
+        states = {
+            "sensor.solcast_remaining": {"state": "unavailable", "attributes": {}}
+        }
         data = provider.get_forecast(states)
         assert data.remaining_today_kwh == 0.0
         assert data.hourly_breakdown == []
@@ -162,14 +173,17 @@ class TestSolcastProvider:
     def test_hourly_forecast_fields(self):
         """HourlyForecast contains start, end, expected_kwh, expected_watts."""
         provider = SolcastProvider("sensor.solcast_remaining")
-        now = datetime(2026, 3, 22, 14, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 14, 0, 0, tzinfo=UTC)
         states = {
             "sensor.solcast_remaining": {
                 "state": "6.0",
                 "attributes": {
                     "forecasts": [
                         {"period_start": now.isoformat(), "pv_estimate": 3.0},
-                        {"period_start": now.replace(minute=30).isoformat(), "pv_estimate": 3.0},
+                        {
+                            "period_start": now.replace(minute=30).isoformat(),
+                            "pv_estimate": 3.0,
+                        },
                     ],
                 },
             },
@@ -194,6 +208,7 @@ class TestSolcastProvider:
         _parse_iso only accepted strings, causing TypeError on datetime objects.
         """
         from datetime import timedelta
+
         provider = SolcastProvider("sensor.solcast")
         tz = timezone(timedelta(hours=2))
         now = datetime(2026, 4, 5, 10, 0, tzinfo=tz)
@@ -205,7 +220,10 @@ class TestSolcastProvider:
                         {"period_start": now, "pv_estimate": 2.0},
                         {"period_start": now.replace(minute=30), "pv_estimate": 3.0},
                         {"period_start": now.replace(hour=11), "pv_estimate": 4.0},
-                        {"period_start": now.replace(hour=11, minute=30), "pv_estimate": 5.0},
+                        {
+                            "period_start": now.replace(hour=11, minute=30),
+                            "pv_estimate": 5.0,
+                        },
                     ],
                 },
             },
@@ -214,21 +232,30 @@ class TestSolcastProvider:
         assert data.remaining_today_kwh == 30.0
         assert len(data.hourly_breakdown) == 2
         # Hour 10: avg 2.5kW, each 30-min slot contributes kW*0.5
-        assert pytest.approx(data.hourly_breakdown[0].expected_kwh) == 2.0 * 0.5 + 3.0 * 0.5
+        assert (
+            pytest.approx(data.hourly_breakdown[0].expected_kwh)
+            == 2.0 * 0.5 + 3.0 * 0.5
+        )
         # Hour 11: avg 4.5kW
-        assert pytest.approx(data.hourly_breakdown[1].expected_kwh) == 4.0 * 0.5 + 5.0 * 0.5
+        assert (
+            pytest.approx(data.hourly_breakdown[1].expected_kwh)
+            == 4.0 * 0.5 + 5.0 * 0.5
+        )
 
     def test_detailedForecast_attribute_used(self):
         """Solcast HACS integration uses 'detailedForecast' not 'forecasts'."""
         provider = SolcastProvider("sensor.solcast")
-        now = datetime(2026, 4, 5, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 5, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.solcast": {
                 "state": "20.0",
                 "attributes": {
                     "detailedForecast": [
                         {"period_start": now.isoformat(), "pv_estimate": 3.0},
-                        {"period_start": now.replace(minute=30).isoformat(), "pv_estimate": 3.0},
+                        {
+                            "period_start": now.replace(minute=30).isoformat(),
+                            "pv_estimate": 3.0,
+                        },
                     ],
                 },
             },
@@ -240,7 +267,7 @@ class TestSolcastProvider:
     def test_detailedHourly_attribute_fallback(self):
         """Falls back to detailedHourly if neither forecasts nor detailedForecast exist."""
         provider = SolcastProvider("sensor.solcast")
-        now = datetime(2026, 4, 5, 14, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 4, 5, 14, 0, 0, tzinfo=UTC)
         states = {
             "sensor.solcast": {
                 "state": "10.0",
@@ -259,11 +286,12 @@ class TestSolcastProvider:
 # TestForecastSolarProvider
 # ---------------------------------------------------------------------------
 
+
 class TestForecastSolarProvider:
     def test_reads_watts_dict(self):
         """ForecastSolarProvider reads watts breakdown from attributes."""
         provider = ForecastSolarProvider("sensor.forecast_solar")
-        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
         hour_str = now.replace(minute=0, second=0, microsecond=0).isoformat()
         states = {
             "sensor.forecast_solar": {
@@ -282,7 +310,7 @@ class TestForecastSolarProvider:
     def test_watts_dict_converts_to_hourly_forecast(self):
         """Each watts entry becomes one HourlyForecast with correct kWh."""
         provider = ForecastSolarProvider("sensor.forecast_solar")
-        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=UTC)
         states = {
             "sensor.forecast_solar": {
                 "state": "8.0",
@@ -302,7 +330,7 @@ class TestForecastSolarProvider:
     def test_multiple_hours(self):
         """Multiple watts entries produce multiple HourlyForecast entries."""
         provider = ForecastSolarProvider("sensor.forecast_solar")
-        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 10, 0, 0, tzinfo=UTC)
         hour2 = now.replace(hour=11)
         states = {
             "sensor.forecast_solar": {
@@ -344,7 +372,7 @@ class TestForecastSolarProvider:
     def test_tomorrow_total_kwh_is_none(self):
         """ForecastSolarProvider does not provide tomorrow total."""
         provider = ForecastSolarProvider("sensor.forecast_solar")
-        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
         states = {
             "sensor.forecast_solar": {
                 "state": "4.0",
@@ -357,7 +385,7 @@ class TestForecastSolarProvider:
     def test_hourly_forecast_start_end(self):
         """HourlyForecast start and end span exactly one hour."""
         provider = ForecastSolarProvider("sensor.forecast_solar")
-        now = datetime(2026, 3, 22, 9, 0, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 3, 22, 9, 0, 0, tzinfo=UTC)
         states = {
             "sensor.forecast_solar": {
                 "state": "3.0",
@@ -377,6 +405,7 @@ class TestForecastSolarProvider:
 # ---------------------------------------------------------------------------
 # TestCreateForecastProvider
 # ---------------------------------------------------------------------------
+
 
 class TestCreateForecastProvider:
     def test_create_generic(self):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 """Tests for sensor combiner helpers (Task 18)."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -14,6 +15,7 @@ from custom_components.pv_excess_control.helpers import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_hass(states: dict[str, str | None]) -> MagicMock:
     """Build a minimal mock hass whose states.get() returns stub state objects."""
@@ -34,6 +36,7 @@ def _make_hass(states: dict[str, str | None]) -> MagicMock:
 # ---------------------------------------------------------------------------
 # TestSumCombiner
 # ---------------------------------------------------------------------------
+
 
 class TestSumCombiner:
     def test_sum_all_values(self):
@@ -72,6 +75,7 @@ class TestSumCombiner:
 # ---------------------------------------------------------------------------
 # TestWeightedAverage
 # ---------------------------------------------------------------------------
+
 
 class TestWeightedAverage:
     def test_weighted_average_batteries(self):
@@ -125,13 +129,16 @@ class TestWeightedAverage:
 # TestReadMultipleSensors
 # ---------------------------------------------------------------------------
 
+
 class TestReadMultipleSensors:
     def test_reads_values(self):
         """Reads float values from mock HA states."""
-        hass = _make_hass({
-            "sensor.inv1_power": "1500.5",
-            "sensor.inv2_power": "2000.0",
-        })
+        hass = _make_hass(
+            {
+                "sensor.inv1_power": "1500.5",
+                "sensor.inv2_power": "2000.0",
+            }
+        )
         values, labels = read_multiple_sensors(
             hass,
             ["sensor.inv1_power", "sensor.inv2_power"],
@@ -141,10 +148,12 @@ class TestReadMultipleSensors:
 
     def test_unavailable_returns_none(self):
         """Unavailable sensors return None."""
-        hass = _make_hass({
-            "sensor.inv1_power": "unavailable",
-            "sensor.inv2_power": "1000.0",
-        })
+        hass = _make_hass(
+            {
+                "sensor.inv1_power": "unavailable",
+                "sensor.inv2_power": "1000.0",
+            }
+        )
         values, labels = read_multiple_sensors(
             hass,
             ["sensor.inv1_power", "sensor.inv2_power"],
@@ -185,11 +194,13 @@ class TestReadMultipleSensors:
 
     def test_integration_sum_of_read_sensors(self):
         """read_multiple_sensors output can be fed directly into sum_values."""
-        hass = _make_hass({
-            "sensor.inv1": "1000.0",
-            "sensor.inv2": "unavailable",
-            "sensor.inv3": "2000.0",
-        })
+        hass = _make_hass(
+            {
+                "sensor.inv1": "1000.0",
+                "sensor.inv2": "unavailable",
+                "sensor.inv3": "2000.0",
+            }
+        )
         values, labels = read_multiple_sensors(
             hass,
             ["sensor.inv1", "sensor.inv2", "sensor.inv3"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,11 +4,11 @@ Uses standard unittest.mock since pytest-homeassistant-custom-component
 is not available. These tests verify the production logic is correct
 and can be adapted to use HA test fixtures later.
 """
+
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta, timezone
-from types import SimpleNamespace
+from datetime import datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -52,6 +52,7 @@ from custom_components.pv_excess_control.models import (
 # ---------------------------------------------------------------------------
 # Mock helpers
 # ---------------------------------------------------------------------------
+
 
 class MockState:
     """Minimal mock for an HA state object."""
@@ -99,7 +100,9 @@ class MockHttp:
     def __init__(self) -> None:
         self._registered: list[tuple[str, str]] = []
 
-    def register_static_path(self, url_path: str, path: str, cache_headers: bool = True) -> None:
+    def register_static_path(
+        self, url_path: str, path: str, cache_headers: bool = True
+    ) -> None:
         self._registered.append((url_path, path))
 
 
@@ -126,7 +129,9 @@ class MockHass:
         self.async_add_job = MagicMock()
         self.loop = asyncio.get_event_loop()
         # async_create_task needed by DataUpdateCoordinator
-        self.async_create_task = MagicMock(side_effect=lambda coro, **kw: asyncio.ensure_future(coro))
+        self.async_create_task = MagicMock(
+            side_effect=lambda coro, **kw: asyncio.ensure_future(coro)
+        )
 
 
 def _make_config_entry(
@@ -216,9 +221,7 @@ def _make_coordinator(
         CONF_BATTERY_STRATEGY, BatteryStrategy.BALANCED
     )
 
-    coord._plan_influence = entry.data.get(
-        CONF_PLAN_INFLUENCE, PlanInfluence.LIGHT
-    )
+    coord._plan_influence = entry.data.get(CONF_PLAN_INFLUENCE, PlanInfluence.LIGHT)
     coord._last_discharge_limit = None
     coord._last_state_change = {}
     coord._last_applied_current = {}
@@ -244,7 +247,9 @@ def _make_coordinator(
 
     coord.analytics = AnalyticsTracker(feed_in_tariff=0.0, normal_import_price=0.25)
     coord.notifications = NotificationManager(
-        hass, notification_settings=None, notification_service=None,
+        hass,
+        notification_settings=None,
+        notification_service=None,
     )
 
     return coord
@@ -306,16 +311,18 @@ class TestCollectPowerState:
 
     def test_combined_import_export_sensor_positive(self):
         """Combined import/export sensor: positive = export."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_IMPORT_EXPORT: "sensor.grid_power",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_IMPORT_EXPORT: "sensor.grid_power",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_power": MockState("1500"),  # exporting
@@ -331,16 +338,18 @@ class TestCollectPowerState:
 
     def test_combined_import_export_sensor_negative(self):
         """Combined import/export sensor: negative = import."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_IMPORT_EXPORT: "sensor.grid_power",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_IMPORT_EXPORT: "sensor.grid_power",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("500"),
             "sensor.grid_power": MockState("-800"),  # importing
@@ -356,18 +365,20 @@ class TestCollectPowerState:
 
     def test_battery_sensors_read(self):
         """Battery SOC and power sensors are read when configured."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_SOC: "sensor.battery_soc",
-            "battery_power": "sensor.battery_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_SOC: "sensor.battery_soc",
+                "battery_power": "sensor.battery_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("5000"),
             "sensor.grid_export": MockState("2000"),
@@ -385,19 +396,21 @@ class TestCollectPowerState:
 
     def test_separate_battery_charge_discharge_sensors(self):
         """Separate charge/discharge sensors are combined into battery_power."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_SOC: "sensor.battery_soc",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_SOC: "sensor.battery_soc",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("5000"),
             "sensor.grid_export": MockState("2000"),
@@ -417,19 +430,21 @@ class TestCollectPowerState:
 
     def test_separate_battery_sensors_discharging(self):
         """Separate sensors when battery is discharging."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_SOC: "sensor.battery_soc",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_SOC: "sensor.battery_soc",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("500"),
             "sensor.grid_export": MockState("0"),
@@ -448,20 +463,22 @@ class TestCollectPowerState:
 
     def test_combined_battery_sensor_takes_precedence(self):
         """When combined battery_power is set, it takes precedence over separate sensors."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_SOC: "sensor.battery_soc",
-            CONF_BATTERY_POWER: "sensor.battery_combined",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_SOC: "sensor.battery_soc",
+                CONF_BATTERY_POWER: "sensor.battery_combined",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("5000"),
             "sensor.grid_export": MockState("2000"),
@@ -481,15 +498,17 @@ class TestCollectPowerState:
 
     def test_excess_calculated_from_grid_when_no_load(self):
         """When load_power is 0 or unavailable, excess = grid_export - grid_import."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("3000"),
             "sensor.grid_export": MockState("1500"),
@@ -507,18 +526,20 @@ class TestCollectPowerState:
         positive grid_export reading must NOT cause excess to collapse to
         the export value. Excess should reflect pv - load (the surplus
         currently being absorbed by the battery)."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4216"),
             "sensor.grid_export": MockState("5"),  # <-- the bug trigger
@@ -540,18 +561,20 @@ class TestCollectPowerState:
         excess must equal pv - load. (Today's code happens to return
         the same value via the existing fallback; this test guards
         against a future regression of the new branch.)"""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4200"),
             "sensor.grid_export": MockState("0"),
@@ -570,18 +593,20 @@ class TestCollectPowerState:
         """Battery near full: even with a large positive grid_export,
         the new branch must use pv - load. This proves the topology
         check (has_battery) wins over the magnitude of grid_export."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("5000"),
             "sensor.grid_export": MockState("4000"),  # battery near full
@@ -600,18 +625,20 @@ class TestCollectPowerState:
     def test_hybrid_battery_discharging_pv_minus_load_goes_negative(self):
         """Evening sanity check: when the battery is discharging and load
         exceeds PV, excess must go negative so the optimizer sheds."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("200"),
             "sensor.grid_export": MockState("0"),
@@ -630,17 +657,19 @@ class TestCollectPowerState:
     def test_hybrid_uses_combined_battery_power_sensor(self):
         """has_battery must also detect the combined CONF_BATTERY_POWER
         configuration, not just separate charge/discharge sensors."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_POWER: "sensor.battery_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_POWER: "sensor.battery_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4500"),
             "sensor.grid_export": MockState("8"),  # tiny positive
@@ -659,16 +688,18 @@ class TestCollectPowerState:
         """Regression guard: pure-inverter setups (no battery sensor)
         must still use grid_export when it's positive. This is the
         byte-for-byte unchanged path."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_export": MockState("1200"),
@@ -688,18 +719,20 @@ class TestCollectPowerState:
         """Regression guard: combined import/export sensor topology
         must take precedence over has_battery and use the
         grid_export - grid_import formula unchanged."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_IMPORT_EXPORT: "sensor.grid_power",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_IMPORT_EXPORT: "sensor.grid_power",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_power": MockState("1500"),  # combined: positive = export
@@ -717,18 +750,20 @@ class TestCollectPowerState:
 
     def test_pv_unavailable_hybrid_branch_returns_none_excess(self):
         """Hybrid config, PV sensor unavailable → excess and pv_production both None."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("unavailable"),
             "sensor.grid_export": MockState("0"),
@@ -746,18 +781,20 @@ class TestCollectPowerState:
 
     def test_load_unavailable_hybrid_with_grid_export_zero_returns_none(self):
         """Hybrid config, load unavailable, grid_export=0 → fallback needs load → None."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_export": MockState("0"),
@@ -779,16 +816,18 @@ class TestCollectPowerState:
         The grid_export branch does not need PV, so excess_power equals
         grid_export. pv_production is still None in PowerState.
         """
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("unavailable"),
             "sensor.grid_export": MockState("1200"),
@@ -804,16 +843,18 @@ class TestCollectPowerState:
 
     def test_pv_unavailable_non_hybrid_grid_export_fallback_returns_none(self):
         """Pure inverter, PV unavailable, grid_export == 0 → fallback needs PV → None."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("unavailable"),
             "sensor.grid_export": MockState("0"),
@@ -833,16 +874,18 @@ class TestCollectPowerState:
         Nuance 1a from the spec: user configured grid_export as their truth
         source; silently switching to pv-load would mask the misconfiguration.
         """
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_export": MockState("unavailable"),
@@ -858,16 +901,18 @@ class TestCollectPowerState:
 
     def test_combined_import_export_unavailable_returns_none(self):
         """Combined sensor topology, combined sensor unavailable → excess=None."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_IMPORT_EXPORT: "sensor.grid_power",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_IMPORT_EXPORT: "sensor.grid_power",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_power": MockState("unavailable"),
@@ -888,18 +933,20 @@ class TestCollectPowerState:
         Hybrid predicate is False (load_power is None), so it falls through
         to the grid_export_entity branch. grid_export=1500>0 → excess=1500.
         """
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_export": MockState("1500"),
@@ -917,18 +964,20 @@ class TestCollectPowerState:
 
     def test_all_sensors_good_hybrid_still_works(self):
         """Regression guard: hybrid happy path still produces pv-load."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("4500"),
             "sensor.grid_export": MockState("0"),
@@ -947,16 +996,18 @@ class TestCollectPowerState:
 
     def test_upstream_sensor_fields_are_none_when_unavailable(self):
         """PowerState upstream fields are None (not 0.0) when sensors are unavailable."""
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         states = {
             "sensor.pv_power": MockState("unavailable"),
             "sensor.grid_export": MockState("unavailable"),
@@ -974,18 +1025,21 @@ class TestCollectPowerState:
     def test_sensor_unavailable_logs_warning_once(self, caplog):
         """First cycle after transition: one WARNING. Subsequent cycles: no additional log."""
         import logging
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         good_states = {
             "sensor.pv_power": MockState("4000"),
             "sensor.grid_export": MockState("0"),
@@ -1003,11 +1057,14 @@ class TestCollectPowerState:
         # Cycle 2: PV transitions to unavailable.
         hass.states._states["sensor.pv_power"] = MockState("unavailable")
 
-        with caplog.at_level(logging.WARNING, logger="custom_components.pv_excess_control"):
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.pv_excess_control"
+        ):
             coord._collect_power_state()
 
         warnings = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelno == logging.WARNING
             and "sensor.pv_power" in r.getMessage()
             and "unavailable" in r.getMessage().lower()
@@ -1019,7 +1076,9 @@ class TestCollectPowerState:
 
         # Cycle 3: still unavailable — no additional warning
         caplog.clear()
-        with caplog.at_level(logging.WARNING, logger="custom_components.pv_excess_control"):
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.pv_excess_control"
+        ):
             coord._collect_power_state()
 
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
@@ -1030,18 +1089,21 @@ class TestCollectPowerState:
     def test_sensor_recovery_logs_info(self, caplog):
         """Transition unavailable → available: one INFO log line."""
         import logging
-        entry = _make_config_entry(data={
-            CONF_PV_POWER: "sensor.pv_power",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-            CONF_LOAD_POWER: "sensor.load_power",
-            CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
-            CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
-            CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
-            CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
-            CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
-            CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
-            CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
-        })
+
+        entry = _make_config_entry(
+            data={
+                CONF_PV_POWER: "sensor.pv_power",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+                CONF_LOAD_POWER: "sensor.load_power",
+                CONF_BATTERY_CHARGE_POWER: "sensor.battery_charge",
+                CONF_BATTERY_DISCHARGE_POWER: "sensor.battery_discharge",
+                CONF_GRID_VOLTAGE: DEFAULT_GRID_VOLTAGE,
+                CONF_CONTROLLER_INTERVAL: DEFAULT_CONTROLLER_INTERVAL,
+                CONF_PLANNER_INTERVAL: DEFAULT_PLANNER_INTERVAL,
+                CONF_TARIFF_PROVIDER: TariffProviderEnum.NONE,
+                CONF_FORECAST_PROVIDER: ForecastProviderEnum.NONE,
+            }
+        )
         bad_states = {
             "sensor.pv_power": MockState("unavailable"),
             "sensor.grid_export": MockState("0"),
@@ -1059,11 +1121,14 @@ class TestCollectPowerState:
         # Cycle 2: PV recovers
         hass.states._states["sensor.pv_power"] = MockState("4000")
 
-        with caplog.at_level(logging.INFO, logger="custom_components.pv_excess_control"):
+        with caplog.at_level(
+            logging.INFO, logger="custom_components.pv_excess_control"
+        ):
             coord._collect_power_state()
 
         infos = [
-            r for r in caplog.records
+            r
+            for r in caplog.records
             if r.levelno == logging.INFO
             and "sensor.pv_power" in r.getMessage()
             and "available" in r.getMessage().lower()
@@ -1084,11 +1149,13 @@ class TestPowerHistory:
 
     def test_history_appends(self):
         """Power states are appended to history."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("1000"),
-            "sensor.grid_export": MockState("500"),
-            "sensor.load_power": MockState("500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("1000"),
+                "sensor.grid_export": MockState("500"),
+                "sensor.load_power": MockState("500"),
+            }
+        )
 
         ps = coord._collect_power_state()
         coord.power_history.append(ps)
@@ -1100,11 +1167,13 @@ class TestPowerHistory:
         """History is capped at MAX_HISTORY_SIZE entries."""
         from custom_components.pv_excess_control.coordinator import MAX_HISTORY_SIZE
 
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("1000"),
-            "sensor.grid_export": MockState("500"),
-            "sensor.load_power": MockState("500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("1000"),
+                "sensor.grid_export": MockState("500"),
+                "sensor.load_power": MockState("500"),
+            }
+        )
 
         # Fill history beyond max
         for i in range(MAX_HISTORY_SIZE + 20):
@@ -1126,9 +1195,7 @@ class TestPowerHistory:
         assert len(coord.power_history) == MAX_HISTORY_SIZE
         # Oldest entry should have been popped (first entry should be 20)
         assert coord.power_history[0].pv_production == 20.0
-        assert coord.power_history[-1].pv_production == float(
-            MAX_HISTORY_SIZE + 20 - 1
-        )
+        assert coord.power_history[-1].pv_production == float(MAX_HISTORY_SIZE + 20 - 1)
 
 
 # ---------------------------------------------------------------------------
@@ -1141,22 +1208,26 @@ class TestStartupGracePeriod:
 
     def test_grace_period_active_on_startup(self):
         """Coordinator should skip optimization during startup grace period."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("3000"),
-            "sensor.grid_export": MockState("1500"),
-            "sensor.load_power": MockState("1500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("3000"),
+                "sensor.grid_export": MockState("1500"),
+                "sensor.load_power": MockState("1500"),
+            }
+        )
         # Just created, so startup time is now
         elapsed = (datetime.now() - coord._startup_time).total_seconds()
         assert elapsed < DEFAULT_STARTUP_GRACE_PERIOD
 
     def test_grace_period_expired(self):
         """After grace period, optimization should proceed."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("3000"),
-            "sensor.grid_export": MockState("1500"),
-            "sensor.load_power": MockState("1500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("3000"),
+                "sensor.grid_export": MockState("1500"),
+                "sensor.load_power": MockState("1500"),
+            }
+        )
         # Backdate startup time
         coord._startup_time = datetime.now() - timedelta(
             seconds=DEFAULT_STARTUP_GRACE_PERIOD + 10
@@ -1167,11 +1238,13 @@ class TestStartupGracePeriod:
 
     def test_disabled_skips_optimization(self):
         """When disabled, coordinator skips optimization."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("3000"),
-            "sensor.grid_export": MockState("1500"),
-            "sensor.load_power": MockState("1500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("3000"),
+                "sensor.grid_export": MockState("1500"),
+                "sensor.load_power": MockState("1500"),
+            }
+        )
         coord.enabled = False
         assert coord.enabled is False
 
@@ -1221,11 +1294,13 @@ class TestBuildCoordinatorData:
 
     def test_with_power_history(self):
         """Data output includes latest power state."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("3000"),
-            "sensor.grid_export": MockState("1500"),
-            "sensor.load_power": MockState("1500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("3000"),
+                "sensor.grid_export": MockState("1500"),
+                "sensor.load_power": MockState("1500"),
+            }
+        )
 
         ps = coord._collect_power_state()
         coord.power_history.append(ps)
@@ -1388,10 +1463,12 @@ class TestGetApplianceStates:
         assert result["sub_1"].is_on is True
         assert result["sub_1"].appliance_id == "sub_1"
 
-
     def test_disabled_appliance_state_preserved(self):
         """Disabling an appliance should NOT reset its runtime/energy counters."""
-        from custom_components.pv_excess_control.models import ApplianceConfig, ApplianceState
+        from custom_components.pv_excess_control.models import (
+            ApplianceConfig,
+            ApplianceState,
+        )
 
         states = {"switch.pump": MockState("on")}
         # Create a subentry so the coordinator knows the appliance exists
@@ -1412,14 +1489,28 @@ class TestGetApplianceStates:
         coord = _make_coordinator(states=states, entry=entry)
 
         config = ApplianceConfig(
-            id="sub_pump", name="Pool Pump", entity_id="switch.pump",
-            priority=2, phases=1, nominal_power=1000.0, actual_power_entity=None,
-            dynamic_current=False, current_entity=None, min_current=0.0,
-            max_current=16.0, ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=None, max_daily_runtime=None,
-            schedule_deadline=None, switch_interval=300,
-            allow_grid_supplement=False, max_grid_power=None,
+            id="sub_pump",
+            name="Pool Pump",
+            entity_id="switch.pump",
+            priority=2,
+            phases=1,
+            nominal_power=1000.0,
+            actual_power_entity=None,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=16.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
+            max_grid_power=None,
         )
 
         # First call: build state with runtime accumulated
@@ -1428,10 +1519,15 @@ class TestGetApplianceStates:
 
         # Simulate accumulated runtime by setting state directly
         coord.appliance_states["sub_pump"] = ApplianceState(
-            appliance_id="sub_pump", is_on=True, current_power=1000.0,
-            current_amperage=None, runtime_today=timedelta(hours=1, minutes=30),
-            energy_today=1.5, last_state_change=None,
-            ev_connected=None, ev_soc=None,
+            appliance_id="sub_pump",
+            is_on=True,
+            current_power=1000.0,
+            current_amperage=None,
+            runtime_today=timedelta(hours=1, minutes=30),
+            energy_today=1.5,
+            last_state_change=None,
+            ev_connected=None,
+            ev_soc=None,
         )
 
         # Now simulate disabling: call _get_appliance_states with EMPTY configs
@@ -1445,7 +1541,7 @@ class TestGetApplianceStates:
 
     def test_removed_appliance_state_not_preserved(self):
         """State for a completely removed appliance (no subentry) should NOT be preserved."""
-        from custom_components.pv_excess_control.models import ApplianceConfig, ApplianceState
+        from custom_components.pv_excess_control.models import ApplianceState
 
         states = {"switch.pump": MockState("on")}
         # No subentries — the appliance was fully removed
@@ -1454,10 +1550,15 @@ class TestGetApplianceStates:
 
         # Simulate leftover state from before removal
         coord.appliance_states["old_appliance"] = ApplianceState(
-            appliance_id="old_appliance", is_on=False, current_power=0.0,
-            current_amperage=None, runtime_today=timedelta(hours=2),
-            energy_today=3.0, last_state_change=None,
-            ev_connected=None, ev_soc=None,
+            appliance_id="old_appliance",
+            is_on=False,
+            current_power=0.0,
+            current_amperage=None,
+            runtime_today=timedelta(hours=2),
+            energy_today=3.0,
+            last_state_change=None,
+            ev_connected=None,
+            ev_soc=None,
         )
 
         result = coord._get_appliance_states([])
@@ -1510,21 +1611,28 @@ class TestSetupAndUnload:
         )
         from custom_components.pv_excess_control.coordinator import PvExcessCoordinator
 
-        hass = MockHass(states={
-            "sensor.pv_power": MockState("1000"),
-            "sensor.grid_export": MockState("500"),
-            "sensor.load_power": MockState("500"),
-        })
+        hass = MockHass(
+            states={
+                "sensor.pv_power": MockState("1000"),
+                "sensor.grid_export": MockState("500"),
+                "sensor.load_power": MockState("500"),
+            }
+        )
         entry = _make_config_entry()
 
         # Patch the coordinator to avoid real HA DataUpdateCoordinator behavior
-        with patch.object(
-            PvExcessCoordinator, "async_config_entry_first_refresh", new_callable=AsyncMock
-        ) as mock_refresh, patch.object(
-            hass.config_entries,
-            "async_forward_entry_setups",
-            new_callable=AsyncMock,
-        ) as mock_forward:
+        with (
+            patch.object(
+                PvExcessCoordinator,
+                "async_config_entry_first_refresh",
+                new_callable=AsyncMock,
+            ) as mock_refresh,
+            patch.object(
+                hass.config_entries,
+                "async_forward_entry_setups",
+                new_callable=AsyncMock,
+            ) as mock_forward,
+        ):
             result = await async_setup_entry(hass, entry)
 
         assert result is True
@@ -1687,11 +1795,13 @@ class TestUpdateCycle:
     @pytest.mark.asyncio
     async def test_planner_counter_resets(self):
         """Planner counter resets when it reaches the ratio threshold."""
-        coord = _make_coordinator(states={
-            "sensor.pv_power": MockState("1000"),
-            "sensor.grid_export": MockState("500"),
-            "sensor.load_power": MockState("500"),
-        })
+        coord = _make_coordinator(
+            states={
+                "sensor.pv_power": MockState("1000"),
+                "sensor.grid_export": MockState("500"),
+                "sensor.load_power": MockState("500"),
+            }
+        )
 
         # Set counter to one below reset threshold
         ratio = max(
@@ -1720,7 +1830,7 @@ class TestUpdateCycle:
         )
 
         # Must not raise TypeError (or any other exception)
-        data = await coord._async_update_data()
+        await coord._async_update_data()
 
         # PowerState with None fields should be stored in history
         assert len(coord.power_history) == 1
@@ -1843,9 +1953,11 @@ class TestNeededByOthersCooldownBypass:
     def test_cooldown_bypassed_for_appliance_in_needed_by_others(self):
         """The switch-interval guard skips appliances in _needed_by_others."""
         from custom_components.pv_excess_control.models import (
-            ApplianceConfig, BatteryDischargeAction, ControlDecision, Action,
+            ControlDecision,
+            Action,
             OptimizerResult,
         )
+
         states = {"switch.pool_pump": MockState("off")}
         sub_helper = MagicMock()
         sub_helper.data = {
@@ -1880,7 +1992,7 @@ class TestNeededByOthersCooldownBypass:
         coord = _make_coordinator(states=states, entry=entry)
 
         # Populate configs and _needed_by_others
-        configs = coord._get_appliance_configs()
+        coord._get_appliance_configs()
         # Simulate: pool pump was turned off 10 seconds ago (cooldown would
         # normally block the next on-command for 290 more seconds)
         coord._last_state_change["sub_helper"] = datetime.now() - timedelta(seconds=10)
@@ -1913,8 +2025,11 @@ class TestNeededByOthersCooldownBypass:
     def test_cooldown_respected_for_appliance_not_needed_by_others(self):
         """A standalone appliance (not in _needed_by_others) still respects cooldown."""
         from custom_components.pv_excess_control.models import (
-            BatteryDischargeAction, ControlDecision, Action, OptimizerResult,
+            ControlDecision,
+            Action,
+            OptimizerResult,
         )
+
         states = {"switch.standalone": MockState("off")}
         sub = MagicMock()
         sub.data = {
@@ -2015,8 +2130,11 @@ class TestNeededByOthersCooldownBypass:
     def test_off_transition_also_bypasses_cooldown_for_needed_appliance(self):
         """The _needed_by_others bypass applies to OFF commands too, not only ON."""
         from custom_components.pv_excess_control.models import (
-            BatteryDischargeAction, ControlDecision, Action, OptimizerResult,
+            ControlDecision,
+            Action,
+            OptimizerResult,
         )
+
         states = {"switch.pool_pump": MockState("on")}
         sub_helper = MagicMock()
         sub_helper.data = {
@@ -2093,6 +2211,7 @@ class TestActivationCountingOnStateTransition:
 
     def _make_config(self, appliance_id: str = "sub_1", entity_id: str = "switch.test"):
         from custom_components.pv_excess_control.models import ApplianceConfig
+
         return ApplianceConfig(
             id=appliance_id,
             name="Test",

--- a/tests/test_inverter_control.py
+++ b/tests/test_inverter_control.py
@@ -1,4 +1,5 @@
 """Tests for InverterGridChargeController."""
+
 from __future__ import annotations
 
 import pytest
@@ -35,15 +36,30 @@ async def test_engage_full_triple_writes_mode_then_power_then_command():
 
     assert hass.services.async_call.await_count == 3
     assert hass.services.async_call.await_args_list == [
-        call("input_select", "select_option",
-             {"entity_id": "input_select.set_sg_ems_mode", "option": "Forced mode"},
-             blocking=False),
-        call("input_number", "set_value",
-             {"entity_id": "input_number.set_sg_forced_charge_discharge_power", "value": 5000.0},
-             blocking=False),
-        call("input_select", "select_option",
-             {"entity_id": "input_select.set_sg_battery_forced_charge_discharge_cmd", "option": "Forced charge"},
-             blocking=False),
+        call(
+            "input_select",
+            "select_option",
+            {"entity_id": "input_select.set_sg_ems_mode", "option": "Forced mode"},
+            blocking=False,
+        ),
+        call(
+            "input_number",
+            "set_value",
+            {
+                "entity_id": "input_number.set_sg_forced_charge_discharge_power",
+                "value": 5000.0,
+            },
+            blocking=False,
+        ),
+        call(
+            "input_select",
+            "select_option",
+            {
+                "entity_id": "input_select.set_sg_battery_forced_charge_discharge_cmd",
+                "option": "Forced charge",
+            },
+            blocking=False,
+        ),
     ]
 
 
@@ -61,7 +77,10 @@ async def test_engage_skips_mode_when_not_configured():
 
     assert hass.services.async_call.await_count == 1
     assert hass.services.async_call.await_args_list[0] == call(
-        "switch", "turn_on", {"entity_id": "switch.battery_force_charge"}, blocking=False,
+        "switch",
+        "turn_on",
+        {"entity_id": "switch.battery_force_charge"},
+        blocking=False,
     )
 
 
@@ -82,16 +101,26 @@ async def test_engage_skips_power_when_not_configured():
 
     assert hass.services.async_call.await_count == 2
     # mode then enable; no power call
-    assert hass.services.async_call.await_args_list[0].args[:2] == ("input_select", "select_option")
-    assert hass.services.async_call.await_args_list[1].args[:2] == ("input_select", "select_option")
+    assert hass.services.async_call.await_args_list[0].args[:2] == (
+        "input_select",
+        "select_option",
+    )
+    assert hass.services.async_call.await_args_list[1].args[:2] == (
+        "input_select",
+        "select_option",
+    )
 
 
 @pytest.mark.asyncio
 async def test_disengage_writes_command_then_mode_in_reverse():
     hass = _make_hass_with_async_call()
     cfg = InverterGridChargeConfig(
-        enable_entity_id="input_select.cmd", enable_engage_value="Forced charge", enable_disengage_value="Stop",
-        mode_entity_id="input_select.mode", mode_engage_value="Forced", mode_disengage_value="Self",
+        enable_entity_id="input_select.cmd",
+        enable_engage_value="Forced charge",
+        enable_disengage_value="Stop",
+        mode_entity_id="input_select.mode",
+        mode_engage_value="Forced",
+        mode_disengage_value="Self",
         power_entity_id="input_number.power",
     )
     ctl = InverterGridChargeController(hass, cfg)
@@ -100,10 +129,18 @@ async def test_disengage_writes_command_then_mode_in_reverse():
 
     assert hass.services.async_call.await_count == 2
     assert hass.services.async_call.await_args_list == [
-        call("input_select", "select_option",
-             {"entity_id": "input_select.cmd", "option": "Stop"}, blocking=False),
-        call("input_select", "select_option",
-             {"entity_id": "input_select.mode", "option": "Self"}, blocking=False),
+        call(
+            "input_select",
+            "select_option",
+            {"entity_id": "input_select.cmd", "option": "Stop"},
+            blocking=False,
+        ),
+        call(
+            "input_select",
+            "select_option",
+            {"entity_id": "input_select.mode", "option": "Self"},
+            blocking=False,
+        ),
     ]
 
 
@@ -111,7 +148,9 @@ async def test_disengage_writes_command_then_mode_in_reverse():
 async def test_disengage_does_not_touch_power_entity():
     hass = _make_hass_with_async_call()
     cfg = InverterGridChargeConfig(
-        enable_entity_id="input_select.cmd", enable_engage_value="Forced charge", enable_disengage_value="Stop",
+        enable_entity_id="input_select.cmd",
+        enable_engage_value="Forced charge",
+        enable_disengage_value="Stop",
         power_entity_id="input_number.power",
     )
     ctl = InverterGridChargeController(hass, cfg)
@@ -198,8 +237,7 @@ async def test_service_derivation_power_writes_set_value_with_float(domain):
     await ctl.engage(power_w=4321.0)
 
     power_call = next(
-        c for c in hass.services.async_call.await_args_list
-        if c.args[0] == domain
+        c for c in hass.services.async_call.await_args_list if c.args[0] == domain
     )
     assert power_call.args[:2] == (domain, "set_value")
     assert power_call.args[2] == {"entity_id": f"{domain}.power", "value": 4321.0}
@@ -220,7 +258,9 @@ def test_unsupported_enable_domain_raises_value_error_at_construction():
 def test_unsupported_power_domain_raises_value_error_at_construction():
     hass = _make_hass_with_async_call()
     cfg = InverterGridChargeConfig(
-        enable_entity_id="switch.batt", enable_engage_value="on", enable_disengage_value="off",
+        enable_entity_id="switch.batt",
+        enable_engage_value="on",
+        enable_disengage_value="off",
         power_entity_id="sensor.kitchen_temp",  # unsupported
     )
     with pytest.raises(ValueError, match="unsupported domain"):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,7 +1,8 @@
 """Comprehensive tests for PV Excess Control data models."""
+
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta, UTC
 
 import pytest
 
@@ -23,13 +24,16 @@ from custom_components.pv_excess_control.models import (
     TariffWindow,
 )
 
+from dataclasses import FrozenInstanceError
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _utcnow() -> datetime:
-    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
 
 
 def _make_appliance_config(**kwargs) -> ApplianceConfig:
@@ -65,6 +69,7 @@ def _make_appliance_config(**kwargs) -> ApplianceConfig:
 # ---------------------------------------------------------------------------
 # TestPowerState
 # ---------------------------------------------------------------------------
+
 
 class TestPowerState:
     def test_create_with_battery(self):
@@ -135,13 +140,14 @@ class TestPowerState:
             ev_soc=None,
             timestamp=ts,
         )
-        with pytest.raises(Exception):  # frozen dataclass raises FrozenInstanceError
+        with pytest.raises(FrozenInstanceError):
             ps.pv_production = 9999.0  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
 # TestApplianceConfig
 # ---------------------------------------------------------------------------
+
 
 class TestApplianceConfig:
     def test_create_simple_switch(self):
@@ -172,7 +178,7 @@ class TestApplianceConfig:
 
     def test_create_ev_charger_with_all_fields(self):
         deadline = time(7, 0)
-        until = datetime(2026, 3, 23, 7, 0, 0, tzinfo=timezone.utc)
+        until = datetime(2026, 3, 23, 7, 0, 0, tzinfo=UTC)
         cfg = ApplianceConfig(
             id="ev_charger_1",
             name="EV Charger",
@@ -241,10 +247,11 @@ class TestApplianceConfig:
 # TestTariffWindow
 # ---------------------------------------------------------------------------
 
+
 class TestTariffWindow:
     def test_create_basic_window(self):
-        start = datetime(2026, 3, 22, 10, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 3, 22, 11, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 22, 10, 0, tzinfo=UTC)
+        end = datetime(2026, 3, 22, 11, 0, tzinfo=UTC)
         w = TariffWindow(start=start, end=end, price=0.08, is_cheap=True)
         assert w.start == start
         assert w.end == end
@@ -252,23 +259,24 @@ class TestTariffWindow:
         assert w.is_cheap is True
 
     def test_create_expensive_window(self):
-        start = datetime(2026, 3, 22, 18, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 3, 22, 20, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 22, 18, 0, tzinfo=UTC)
+        end = datetime(2026, 3, 22, 20, 0, tzinfo=UTC)
         w = TariffWindow(start=start, end=end, price=0.35, is_cheap=False)
         assert w.is_cheap is False
         assert w.price == 0.35
 
     def test_is_frozen(self):
-        start = datetime(2026, 3, 22, 10, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 3, 22, 11, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 22, 10, 0, tzinfo=UTC)
+        end = datetime(2026, 3, 22, 11, 0, tzinfo=UTC)
         w = TariffWindow(start=start, end=end, price=0.10, is_cheap=False)
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             w.price = 0.99  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
 # TestTariffInfo
 # ---------------------------------------------------------------------------
+
 
 class TestTariffInfo:
     def test_create_and_net_savings(self):
@@ -295,8 +303,8 @@ class TestTariffInfo:
         assert pytest.approx(info.net_savings_per_kwh) == -0.05
 
     def test_with_windows(self):
-        start = datetime(2026, 3, 22, 10, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 3, 22, 11, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 22, 10, 0, tzinfo=UTC)
+        end = datetime(2026, 3, 22, 11, 0, tzinfo=UTC)
         window = TariffWindow(start=start, end=end, price=0.08, is_cheap=True)
         info = TariffInfo(
             current_price=0.25,
@@ -312,6 +320,7 @@ class TestTariffInfo:
 # ---------------------------------------------------------------------------
 # TestControlDecision
 # ---------------------------------------------------------------------------
+
 
 class TestControlDecision:
     def test_create_on_decision(self):
@@ -368,7 +377,7 @@ class TestControlDecision:
             reason="test",
             overrides_plan=False,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             decision.action = Action.OFF  # type: ignore[misc]
 
 
@@ -376,11 +385,12 @@ class TestControlDecision:
 # TestPlan
 # ---------------------------------------------------------------------------
 
+
 class TestPlan:
     def _make_battery_target(self) -> BatteryTarget:
         return BatteryTarget(
             target_soc=90.0,
-            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc),
+            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=UTC),
             strategy=BatteryStrategy.BALANCED,
         )
 
@@ -403,8 +413,8 @@ class TestPlan:
     def test_plan_with_entries(self):
         now = _utcnow()
         bt = self._make_battery_target()
-        start = datetime(2026, 3, 22, 13, 0, tzinfo=timezone.utc)
-        end = datetime(2026, 3, 22, 14, 0, tzinfo=timezone.utc)
+        start = datetime(2026, 3, 22, 13, 0, tzinfo=UTC)
+        end = datetime(2026, 3, 22, 14, 0, tzinfo=UTC)
         window = TariffWindow(start=start, end=end, price=0.08, is_cheap=True)
         entry = PlanEntry(
             appliance_id="appliance_1",
@@ -428,8 +438,20 @@ class TestPlan:
     def test_plan_confidence_range(self):
         now = _utcnow()
         bt = self._make_battery_target()
-        plan_low = Plan(created_at=now, horizon=timedelta(hours=1), entries=[], battery_target=bt, confidence=0.0)
-        plan_high = Plan(created_at=now, horizon=timedelta(hours=1), entries=[], battery_target=bt, confidence=1.0)
+        plan_low = Plan(
+            created_at=now,
+            horizon=timedelta(hours=1),
+            entries=[],
+            battery_target=bt,
+            confidence=0.0,
+        )
+        plan_high = Plan(
+            created_at=now,
+            horizon=timedelta(hours=1),
+            entries=[],
+            battery_target=bt,
+            confidence=1.0,
+        )
         assert plan_low.confidence == 0.0
         assert plan_high.confidence == 1.0
 
@@ -437,6 +459,7 @@ class TestPlan:
 # ---------------------------------------------------------------------------
 # TestOptimizerResult
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerResult:
     def test_create_with_decisions_and_battery_discharge_action(self):
@@ -471,7 +494,7 @@ class TestOptimizerResult:
 
     def test_battery_discharge_action_is_frozen(self):
         bda = BatteryDischargeAction(should_limit=True, max_discharge_watts=2000.0)
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             bda.should_limit = False  # type: ignore[misc]
 
     def test_optimizer_result_decisions_mutable(self):
@@ -492,6 +515,7 @@ class TestOptimizerResult:
 # ---------------------------------------------------------------------------
 # TestEnums
 # ---------------------------------------------------------------------------
+
 
 class TestEnums:
     def test_action_values(self):
@@ -519,6 +543,7 @@ class TestEnums:
 # ---------------------------------------------------------------------------
 # TestBatteryConfig
 # ---------------------------------------------------------------------------
+
 
 class TestBatteryConfig:
     def test_create_battery_config(self):
@@ -563,13 +588,14 @@ class TestBatteryConfig:
             strategy=BatteryStrategy.BALANCED,
             allow_grid_charging=False,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             cfg.target_soc = 50.0  # type: ignore[misc]
 
 
 # ---------------------------------------------------------------------------
 # TestApplianceState
 # ---------------------------------------------------------------------------
+
 
 class TestApplianceState:
     def test_create_basic(self):
@@ -610,9 +636,10 @@ class TestApplianceState:
 # TestBatteryTarget
 # ---------------------------------------------------------------------------
 
+
 class TestBatteryTarget:
     def test_create(self):
-        target_time = datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc)
+        target_time = datetime(2026, 3, 23, 7, 0, tzinfo=UTC)
         bt = BatteryTarget(
             target_soc=95.0,
             target_time=target_time,
@@ -628,5 +655,5 @@ class TestBatteryTarget:
             target_time=_utcnow(),
             strategy=BatteryStrategy.BALANCED,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             bt.target_soc = 50.0  # type: ignore[misc]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,10 +1,10 @@
 """Tests for PV Excess Control notification manager."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 
 from custom_components.pv_excess_control.const import (
     DEFAULT_NOTIFICATION_SETTINGS,
@@ -16,6 +16,7 @@ from custom_components.pv_excess_control.notifications import NotificationManage
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_hass() -> MagicMock:
     """Create a minimal mock HomeAssistant object."""
@@ -30,7 +31,9 @@ def _make_manager(
     service: str | None = None,
 ) -> tuple[MagicMock, NotificationManager]:
     hass = _make_hass()
-    manager = NotificationManager(hass, notification_settings=settings, notification_service=service)
+    manager = NotificationManager(
+        hass, notification_settings=settings, notification_service=service
+    )
     return hass, manager
 
 
@@ -38,13 +41,16 @@ def _make_manager(
 # TestNotificationManager
 # ---------------------------------------------------------------------------
 
+
 class TestNotificationManager:
     async def test_enabled_event_sends(self):
         """Enabled events send notifications."""
         settings = {NotificationEvent.SENSOR_UNAVAILABLE: True}
         hass, manager = _make_manager(settings=settings)
 
-        result = await manager.async_notify(NotificationEvent.SENSOR_UNAVAILABLE, "Test message")
+        result = await manager.async_notify(
+            NotificationEvent.SENSOR_UNAVAILABLE, "Test message"
+        )
 
         assert result is True
         hass.services.async_call.assert_awaited_once()
@@ -54,7 +60,9 @@ class TestNotificationManager:
         settings = {NotificationEvent.APPLIANCE_ON: False}
         hass, manager = _make_manager(settings=settings)
 
-        result = await manager.async_notify(NotificationEvent.APPLIANCE_ON, "Appliance on")
+        result = await manager.async_notify(
+            NotificationEvent.APPLIANCE_ON, "Appliance on"
+        )
 
         assert result is False
         hass.services.async_call.assert_not_awaited()
@@ -88,7 +96,9 @@ class TestNotificationManager:
         past_time = datetime.now() - timedelta(seconds=301)
         manager._last_sent[NotificationEvent.FORCE_CHARGE] = past_time
 
-        result = await manager.async_notify(NotificationEvent.FORCE_CHARGE, "After window")
+        result = await manager.async_notify(
+            NotificationEvent.FORCE_CHARGE, "After window"
+        )
 
         assert result is True
         hass.services.async_call.assert_awaited_once()
@@ -96,9 +106,13 @@ class TestNotificationManager:
     async def test_custom_service(self):
         """Custom notification service used when configured."""
         settings = {NotificationEvent.OVERRIDE_ACTIVATED: True}
-        hass, manager = _make_manager(settings=settings, service="notify.mobile_app_phone")
+        hass, manager = _make_manager(
+            settings=settings, service="notify.mobile_app_phone"
+        )
 
-        await manager.async_notify(NotificationEvent.OVERRIDE_ACTIVATED, "Override active")
+        await manager.async_notify(
+            NotificationEvent.OVERRIDE_ACTIVATED, "Override active"
+        )
 
         hass.services.async_call.assert_awaited_once_with(
             "notify",
@@ -109,7 +123,9 @@ class TestNotificationManager:
     async def test_custom_service_with_subdomain(self):
         """Custom service with dots in name is split at first dot."""
         settings = {NotificationEvent.OVERRIDE_ACTIVATED: True}
-        hass, manager = _make_manager(settings=settings, service="notify.group.all_devices")
+        hass, manager = _make_manager(
+            settings=settings, service="notify.group.all_devices"
+        )
 
         await manager.async_notify(NotificationEvent.OVERRIDE_ACTIVATED, "msg")
 
@@ -141,7 +157,9 @@ class TestNotificationManager:
         settings = {NotificationEvent.FORCE_CHARGE: True}
         hass, manager = _make_manager(settings=settings)
 
-        await manager.async_notify(NotificationEvent.FORCE_CHARGE, "msg", title="My Title")
+        await manager.async_notify(
+            NotificationEvent.FORCE_CHARGE, "msg", title="My Title"
+        )
 
         service_data = hass.services.async_call.call_args.args[2]
         assert service_data["title"] == "My Title"
@@ -180,7 +198,9 @@ class TestNotificationManager:
         await manager.notify_appliance_off("Hot Water Heater", "insufficient excess")
 
         service_data = hass.services.async_call.call_args.args[2]
-        assert service_data["message"] == "Hot Water Heater stopped: insufficient excess"
+        assert (
+            service_data["message"] == "Hot Water Heater stopped: insufficient excess"
+        )
 
     async def test_override_message_without_until(self):
         """Override notification message without an end time."""
@@ -242,27 +262,40 @@ class TestNotificationManager:
         await manager.notify_daily_summary(ratio=82.0, savings=3.40, solar_kwh=18.2)
 
         service_data = hass.services.async_call.call_args.args[2]
-        assert service_data["message"] == "Today: 82% self-consumption, saved 3.40, 18.2 kWh solar"
+        assert (
+            service_data["message"]
+            == "Today: 82% self-consumption, saved 3.40, 18.2 kWh solar"
+        )
 
     async def test_forecast_warning_message(self):
         """Correct message format for forecast warning."""
         settings = {NotificationEvent.FORECAST_WARNING: True}
         hass, manager = _make_manager(settings=settings)
 
-        await manager.notify_forecast_warning(tomorrow_kwh=4.2, actions="Pre-heating scheduled.")
+        await manager.notify_forecast_warning(
+            tomorrow_kwh=4.2, actions="Pre-heating scheduled."
+        )
 
         service_data = hass.services.async_call.call_args.args[2]
-        assert service_data["message"] == "Tomorrow: low solar (4.2 kWh). Pre-heating scheduled."
+        assert (
+            service_data["message"]
+            == "Tomorrow: low solar (4.2 kWh). Pre-heating scheduled."
+        )
 
     async def test_plan_deviation_message(self):
         """Correct message format for plan deviation."""
         settings = {NotificationEvent.PLAN_DEVIATION: True}
         hass, manager = _make_manager(settings=settings)
 
-        await manager.notify_plan_deviation("EV Charger", "actual solar 40% below forecast")
+        await manager.notify_plan_deviation(
+            "EV Charger", "actual solar 40% below forecast"
+        )
 
         service_data = hass.services.async_call.call_args.args[2]
-        assert service_data["message"] == "EV Charger deviated from plan: actual solar 40% below forecast"
+        assert (
+            service_data["message"]
+            == "EV Charger deviated from plan: actual solar 40% below forecast"
+        )
 
     async def test_all_event_types_have_methods(self):
         """All NotificationEvent types have convenience methods."""
@@ -297,7 +330,9 @@ class TestNotificationManager:
             NotificationEvent.FORCE_CHARGE,
             NotificationEvent.SENSOR_UNAVAILABLE,
         ):
-            assert manager.settings[event] is True, f"{event} should be enabled by default"
+            assert manager.settings[event] is True, (
+                f"{event} should be enabled by default"
+            )
 
     async def test_default_settings_events_disabled(self):
         """Events disabled by default are inactive."""
@@ -310,7 +345,9 @@ class TestNotificationManager:
             NotificationEvent.FORECAST_WARNING,
             NotificationEvent.PLAN_DEVIATION,
         ):
-            assert manager.settings[event] is False, f"{event} should be disabled by default"
+            assert manager.settings[event] is False, (
+                f"{event} should be disabled by default"
+            )
 
     async def test_returns_false_when_disabled(self):
         """Convenience methods return False when event is disabled."""

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -4642,6 +4642,60 @@ class TestDualBudgetInvariant:
                 f"got {kona_decision.target_current:.2f} A"
             )
 
+    @pytest.mark.parametrize(
+        ("controller_interval", "averaging_window", "expected_average"),
+        [
+            (15, 60, 250.0),
+            (60, 120, 350.0),
+        ],
+    )
+    def test_per_appliance_averaging_window_uses_controller_interval(
+        self,
+        controller_interval,
+        averaging_window,
+        expected_average,
+    ):
+        """Custom averaging windows must respect the configured controller interval."""
+        import dataclasses
+
+        appliance = dataclasses.replace(
+            _make_appliance(
+                id="test_app",
+                nominal_power=1000.0,
+                on_threshold=0,
+            ),
+            averaging_window=averaging_window,
+        )
+        state = _make_state(id="test_app")
+
+        # Ordered oldest -> newest.
+        #
+        # At 15s interval  60s window:
+        #   last 4 samples = 100, 200, 300, 400 -> avg 250 W
+        #
+        # At 60s interval  120s window:
+        #   last 2 samples = 300, 400 -> avg 350 W
+        history = [
+            _make_power(excess=value)
+            for value in (0.0, 0.0, 100.0, 200.0, 300.0, 400.0)
+        ]
+
+        optimizer = _optimizer_for_tests(
+            controller_interval=controller_interval,
+        )
+        result = optimizer.optimize(
+            power_state=_make_power(excess=400.0),
+            appliances=[appliance],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=history,
+            tariff=_make_tariff(),
+        )
+
+        decision = result.decisions[0]
+        assert decision.action == Action.IDLE
+        assert f"Insufficient excess ({expected_average:.0f}W" in decision.reason
+
 
 class TestDynamicCurrentBumpClamp:
     """Pin the min(instant_budget, avg_budget) asymmetric clamp behavior

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,17 +1,12 @@
 """Tests for PV Excess Control optimizer - Phases 1 (ASSESS) & 2 (ALLOCATE)."""
+
 from __future__ import annotations
 
 import math
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
 import pytest
 
-from custom_components.pv_excess_control.const import (
-    DEFAULT_DYNAMIC_ON_THRESHOLD,
-    DEFAULT_GRID_VOLTAGE,
-    DEFAULT_OFF_THRESHOLD,
-    DEFAULT_ON_THRESHOLD,
-)
 from custom_components.pv_excess_control.models import (
     Action,
     ApplianceConfig,
@@ -20,7 +15,6 @@ from custom_components.pv_excess_control.models import (
     BatteryStrategy,
     BatteryTarget,
     ControlDecision,
-    OptimizerResult,
     Plan,
     PlanEntry,
     PlanReason,
@@ -34,6 +28,7 @@ from custom_components.pv_excess_control.optimizer import Optimizer
 # ---------------------------------------------------------------------------
 # Test-only optimizer factory
 # ---------------------------------------------------------------------------
+
 
 def _optimizer_for_tests(**kwargs) -> Optimizer:
     """Build an optimizer for unit tests.
@@ -54,8 +49,9 @@ def _optimizer_for_tests(**kwargs) -> Optimizer:
 # Helpers (reusable in Tasks 4-5)
 # ---------------------------------------------------------------------------
 
+
 def _utcnow() -> datetime:
-    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
 
 
 def _make_appliance(
@@ -179,7 +175,7 @@ def _empty_plan() -> Plan:
         entries=[],
         battery_target=BatteryTarget(
             target_soc=90.0,
-            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc),
+            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=UTC),
             strategy=BatteryStrategy.BALANCED,
         ),
         confidence=0.8,
@@ -189,6 +185,7 @@ def _empty_plan() -> Plan:
 # ---------------------------------------------------------------------------
 # TestOptimizerAllocate
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerAllocate:
     """Test Phase 2: ALLOCATE logic."""
@@ -311,6 +308,7 @@ class TestOptimizerAllocate:
 # TestOptimizerHysteresis
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerHysteresis:
     """Test Phase 1: ASSESS hysteresis logic."""
 
@@ -361,6 +359,7 @@ class TestOptimizerHysteresis:
 # ---------------------------------------------------------------------------
 # TestOptimizerDynamicCurrent
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerDynamicCurrent:
     """Test dynamic current allocation for EV chargers and similar appliances."""
@@ -552,6 +551,7 @@ class TestOptimizerDynamicCurrent:
 # TestOptimizerRemainingExcess
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerBudgets:
     """Test that the avg_budget is tracked correctly across allocations."""
 
@@ -606,6 +606,7 @@ class TestOptimizerBudgets:
 # TestOptimizerBatteryDischarge
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerBatteryDischarge:
     """Test that battery discharge action is a placeholder for Phases 3-5."""
 
@@ -628,6 +629,7 @@ class TestOptimizerBatteryDischarge:
 # ---------------------------------------------------------------------------
 # TestOptimizerPowerHistory
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerPowerHistory:
     """Test that average excess is computed from power_history."""
@@ -664,6 +666,7 @@ class TestOptimizerPowerHistory:
 # TestOptimizerOnOnly
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerOnOnly:
     """Test on_only appliances that should never be turned off once on."""
 
@@ -691,6 +694,7 @@ class TestOptimizerOnOnly:
 # ---------------------------------------------------------------------------
 # TestOptimizerShed
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerShed:
     """Test Phase 3: SHED logic - reduce/turn off lowest priority first."""
@@ -725,7 +729,9 @@ class TestOptimizerShed:
         """Appliances with on_only=True should never be shed."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(
-            id="on_only_app", on_only=True, nominal_power=1000.0,
+            id="on_only_app",
+            on_only=True,
+            nominal_power=1000.0,
         )
         state = _make_state(id="on_only_app", is_on=True, current_power=1000.0)
         # Excess is -500W
@@ -750,20 +756,28 @@ class TestOptimizerShed:
         # Two appliances with same priority
         # app_met has run 3h out of min 2h -> met minimum
         app_met = _make_appliance(
-            id="met", priority=5, nominal_power=1000.0,
+            id="met",
+            priority=5,
+            nominal_power=1000.0,
             min_daily_runtime=timedelta(hours=2),
         )
         # app_unmet has run 1h out of min 4h -> not met minimum
         app_unmet = _make_appliance(
-            id="unmet", priority=5, nominal_power=1000.0,
+            id="unmet",
+            priority=5,
+            nominal_power=1000.0,
             min_daily_runtime=timedelta(hours=4),
         )
         state_met = _make_state(
-            id="met", is_on=True, current_power=1000.0,
+            id="met",
+            is_on=True,
+            current_power=1000.0,
             runtime_today=timedelta(hours=3),
         )
         state_unmet = _make_state(
-            id="unmet", is_on=True, current_power=1000.0,
+            id="unmet",
+            is_on=True,
+            current_power=1000.0,
             runtime_today=timedelta(hours=1),
         )
         # Only need to shed one appliance worth of power (-500W deficit, 1000W each)
@@ -789,6 +803,7 @@ class TestOptimizerShed:
 # TestOptimizerDynamicCurrentShed
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerDynamicCurrentShed:
     """Test that shedding reduces dynamic current before turning off."""
 
@@ -807,7 +822,9 @@ class TestOptimizerDynamicCurrentShed:
             priority=5,
         )
         state = _make_state(
-            id="ev_charger", is_on=True, current_power=3680.0,
+            id="ev_charger",
+            is_on=True,
+            current_power=3680.0,
         )
         # Excess drops but not catastrophically: -1000W
         # Currently consuming 3680W. With -1000W excess, available for this
@@ -836,6 +853,7 @@ class TestOptimizerDynamicCurrentShed:
 # ---------------------------------------------------------------------------
 # TestOptimizerBatteryProtection
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerBatteryProtection:
     """Test Phase 4: BATTERY DISCHARGE PROTECTION logic."""
@@ -871,7 +889,8 @@ class TestOptimizerBatteryProtection:
         """Without active big consumers, no discharge limiting."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(
-            id="washer", nominal_power=500.0,
+            id="washer",
+            nominal_power=500.0,
             is_big_consumer=False,
         )
         state = _make_state(id="washer")
@@ -892,12 +911,18 @@ class TestOptimizerBatteryProtection:
         """Multiple big consumers: use the lowest discharge override."""
         optimizer = _optimizer_for_tests()
         app1 = _make_appliance(
-            id="heat_pump", priority=1, nominal_power=1000.0,
-            is_big_consumer=True, battery_max_discharge_override=500.0,
+            id="heat_pump",
+            priority=1,
+            nominal_power=1000.0,
+            is_big_consumer=True,
+            battery_max_discharge_override=500.0,
         )
         app2 = _make_appliance(
-            id="pool_pump", priority=2, nominal_power=1000.0,
-            is_big_consumer=True, battery_max_discharge_override=300.0,
+            id="pool_pump",
+            priority=2,
+            nominal_power=1000.0,
+            is_big_consumer=True,
+            battery_max_discharge_override=300.0,
         )
         state1 = _make_state(id="heat_pump")
         state2 = _make_state(id="pool_pump")
@@ -923,6 +948,7 @@ class TestOptimizerBatteryProtection:
 # ---------------------------------------------------------------------------
 # TestOptimizerTariff
 # ---------------------------------------------------------------------------
+
 
 class TestOptimizerTariff:
     """Test tariff-aware allocation and opportunity cost."""
@@ -1011,7 +1037,10 @@ class TestOptimizerTariff:
         decision = result.decisions[0]
         # Should turn ON via grid supplement: export solar, buy from grid
         assert decision.action == Action.ON
-        assert "grid supplement" in decision.reason.lower() or "export solar" in decision.reason.lower()
+        assert (
+            "grid supplement" in decision.reason.lower()
+            or "export solar" in decision.reason.lower()
+        )
 
     def test_per_appliance_cheap_threshold_allows_supplement(self):
         """Per-appliance threshold (higher) allows grid supplement even when global would block."""
@@ -1099,6 +1128,7 @@ class TestOptimizerTariff:
 # TestOptimizerPlanInfluence
 # ---------------------------------------------------------------------------
 
+
 def _make_plan_with_entry(appliance_id: str = "app_1") -> Plan:
     """Create a Plan with an ON entry for the given appliance in the current time window."""
     now = datetime.now()
@@ -1122,7 +1152,7 @@ def _make_plan_with_entry(appliance_id: str = "app_1") -> Plan:
         entries=[entry],
         battery_target=BatteryTarget(
             target_soc=90.0,
-            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc),
+            target_time=datetime(2026, 3, 23, 7, 0, tzinfo=UTC),
             strategy=BatteryStrategy.BALANCED,
         ),
         confidence=0.8,
@@ -1276,7 +1306,7 @@ class TestOptimizerPlanInfluence:
             entries=[entry],
             battery_target=BatteryTarget(
                 target_soc=90.0,
-                target_time=datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc),
+                target_time=datetime(2026, 3, 23, 7, 0, tzinfo=UTC),
                 strategy=BatteryStrategy.BALANCED,
             ),
             confidence=0.8,
@@ -1301,67 +1331,131 @@ class TestOptimizerPlanInfluence:
 # TestOptimizerDependencies
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerDependencies:
     """Tests for appliance dependency handling."""
 
     def _run(self, appliances, states, excess):
-        history = [PowerState(pv_production=5000, grid_export=excess, grid_import=max(-excess, 0),
-                              load_power=5000-excess, excess_power=excess, battery_soc=None,
-                              battery_power=None, ev_soc=None, timestamp=_utcnow())]
+        history = [
+            PowerState(
+                pv_production=5000,
+                grid_export=excess,
+                grid_import=max(-excess, 0),
+                load_power=5000 - excess,
+                excess_power=excess,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
+                timestamp=_utcnow(),
+            )
+        ]
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=history[0], appliances=appliances, appliance_states=states,
-            plan=Plan(created_at=_utcnow(), horizon=timedelta(hours=24), entries=[],
-                      battery_target=BatteryTarget(target_soc=100, target_time=_utcnow(),
-                                                    strategy=BatteryStrategy.BALANCED),
-                      confidence=0.5),
-            power_history=history, tariff=TariffInfo(current_price=0.30, feed_in_tariff=0.08,
-                                                      cheap_price_threshold=0.10,
-                                                      battery_charge_price_threshold=0.05),
+            power_state=history[0],
+            appliances=appliances,
+            appliance_states=states,
+            plan=Plan(
+                created_at=_utcnow(),
+                horizon=timedelta(hours=24),
+                entries=[],
+                battery_target=BatteryTarget(
+                    target_soc=100,
+                    target_time=_utcnow(),
+                    strategy=BatteryStrategy.BALANCED,
+                ),
+                confidence=0.5,
+            ),
+            power_history=history,
+            tariff=TariffInfo(
+                current_price=0.30,
+                feed_in_tariff=0.08,
+                cheap_price_threshold=0.10,
+                battery_charge_price_threshold=0.05,
+            ),
         )
         return {d.appliance_id: d for d in result.decisions}
 
     def test_dependent_starts_dependency_when_off(self):
         """When heat pump needs pool pump, both start if enough excess."""
-        pump = _make_appliance(id="pump", name="Pool Pump", priority=10, nominal_power=1000.0)
-        heater = _make_appliance(id="heater", name="Heat Pump", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
-        decisions = self._run([pump, heater],
-                              [_make_state(id="pump"), _make_state(id="heater")],
-                              excess=2700)
+        pump = _make_appliance(
+            id="pump", name="Pool Pump", priority=10, nominal_power=1000.0
+        )
+        heater = _make_appliance(
+            id="heater",
+            name="Heat Pump",
+            priority=3,
+            nominal_power=1500.0,
+            requires_appliance="pump",
+        )
+        decisions = self._run(
+            [pump, heater],
+            [_make_state(id="pump"), _make_state(id="heater")],
+            excess=2700,
+        )
         assert decisions["heater"].action == Action.ON
         assert decisions["pump"].action == Action.ON
 
     def test_not_enough_for_both(self):
         """If excess only covers dependent but not dep+dependent, neither starts."""
-        pump = _make_appliance(id="pump", name="Pool Pump", priority=10, nominal_power=1000.0)
-        heater = _make_appliance(id="heater", name="Heat Pump", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
-        decisions = self._run([pump, heater],
-                              [_make_state(id="pump"), _make_state(id="heater")],
-                              excess=2000)
+        pump = _make_appliance(
+            id="pump", name="Pool Pump", priority=10, nominal_power=1000.0
+        )
+        heater = _make_appliance(
+            id="heater",
+            name="Heat Pump",
+            priority=3,
+            nominal_power=1500.0,
+            requires_appliance="pump",
+        )
+        decisions = self._run(
+            [pump, heater],
+            [_make_state(id="pump"), _make_state(id="heater")],
+            excess=2000,
+        )
         assert decisions["heater"].action == Action.IDLE
 
     def test_dependency_already_on(self):
         """If dependency is already running, dependent just needs its own power."""
-        pump = _make_appliance(id="pump", name="Pool Pump", priority=10, nominal_power=1000.0)
-        heater = _make_appliance(id="heater", name="Heat Pump", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
-        decisions = self._run([pump, heater],
-                              [_make_state(id="pump", is_on=True, current_power=1000.0),
-                               _make_state(id="heater")],
-                              excess=1800)
+        pump = _make_appliance(
+            id="pump", name="Pool Pump", priority=10, nominal_power=1000.0
+        )
+        heater = _make_appliance(
+            id="heater",
+            name="Heat Pump",
+            priority=3,
+            nominal_power=1500.0,
+            requires_appliance="pump",
+        )
+        decisions = self._run(
+            [pump, heater],
+            [
+                _make_state(id="pump", is_on=True, current_power=1000.0),
+                _make_state(id="heater"),
+            ],
+            excess=1800,
+        )
         assert decisions["heater"].action == Action.ON
 
     def test_dependency_protected_from_shed(self):
         """Dependency not shed while dependent is running."""
-        pump = _make_appliance(id="pump", name="Pool Pump", priority=10, nominal_power=1000.0)
-        heater = _make_appliance(id="heater", name="Heat Pump", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
-        decisions = self._run([pump, heater],
-                              [_make_state(id="pump", is_on=True, current_power=1000.0),
-                               _make_state(id="heater", is_on=True, current_power=1500.0)],
-                              excess=-100)
+        pump = _make_appliance(
+            id="pump", name="Pool Pump", priority=10, nominal_power=1000.0
+        )
+        heater = _make_appliance(
+            id="heater",
+            name="Heat Pump",
+            priority=3,
+            nominal_power=1500.0,
+            requires_appliance="pump",
+        )
+        decisions = self._run(
+            [pump, heater],
+            [
+                _make_state(id="pump", is_on=True, current_power=1000.0),
+                _make_state(id="heater", is_on=True, current_power=1500.0),
+            ],
+            excess=-100,
+        )
         # Heater gets shed (lowest priority number but highest shed priority = -3 > -10)
         # Wait, shed sorts by -priority: pump=-10, heater=-3. -10 < -3 so pump is FIRST candidate.
         # But pump is protected. Then heater is shed.
@@ -1372,8 +1466,13 @@ class TestOptimizerDependencies:
 
     def test_dependency_disabled_blocks_dependent(self):
         """If dependency is not in config (disabled), dependent can't start."""
-        heater = _make_appliance(id="heater", name="Heat Pump", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
+        heater = _make_appliance(
+            id="heater",
+            name="Heat Pump",
+            priority=3,
+            nominal_power=1500.0,
+            requires_appliance="pump",
+        )
         decisions = self._run([heater], [_make_state(id="heater")], excess=3000)
         assert decisions["heater"].action == Action.IDLE
         assert "dependency" in decisions["heater"].reason.lower()
@@ -1383,20 +1482,28 @@ class TestOptimizerDependencies:
 # TestOptimizerPreemption
 # ---------------------------------------------------------------------------
 
+
 class TestOptimizerPreemption:
     """Tests for Phase 2.5 PREEMPT - shed lower-priority to start higher-priority."""
 
     def test_preempt_lower_for_higher_priority(self):
         """Lower-priority running appliance shed to start higher-priority one."""
         app_a = _make_appliance(id="low", name="Low", priority=5, nominal_power=1000.0)
-        app_b = _make_appliance(id="high", name="High", priority=1, nominal_power=2000.0)
+        app_b = _make_appliance(
+            id="high", name="High", priority=1, nominal_power=2000.0
+        )
         state_a = _make_state(id="low", is_on=True, current_power=1000.0)
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["high"].action == Action.ON
         assert decisions["low"].action == Action.OFF
@@ -1410,56 +1517,88 @@ class TestOptimizerPreemption:
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=3000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["high"].action == Action.ON
         assert decisions["low"].action == Action.ON
 
     def test_no_preempt_on_only(self):
         """on_only appliances are never preempted."""
-        app_a = _make_appliance(id="low", priority=5, nominal_power=1000.0, on_only=True)
+        app_a = _make_appliance(
+            id="low", priority=5, nominal_power=1000.0, on_only=True
+        )
         app_b = _make_appliance(id="high", priority=1, nominal_power=2000.0)
         state_a = _make_state(id="low", is_on=True, current_power=1000.0)
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["low"].action == Action.ON
         assert decisions["high"].action == Action.IDLE
 
     def test_no_preempt_overridden(self):
         """Overridden appliances are never preempted."""
-        app_a = _make_appliance(id="low", priority=5, nominal_power=1000.0, override_active=True)
+        app_a = _make_appliance(
+            id="low", priority=5, nominal_power=1000.0, override_active=True
+        )
         app_b = _make_appliance(id="high", priority=1, nominal_power=2000.0)
         state_a = _make_state(id="low", is_on=True, current_power=1000.0)
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["low"].action == Action.ON
         assert decisions["high"].action == Action.IDLE
 
     def test_no_preempt_min_runtime_unmet(self):
         """Appliances with unmet min_daily_runtime not preempted."""
-        app_a = _make_appliance(id="low", priority=5, nominal_power=1000.0,
-                                min_daily_runtime=timedelta(hours=2))
+        app_a = _make_appliance(
+            id="low",
+            priority=5,
+            nominal_power=1000.0,
+            min_daily_runtime=timedelta(hours=2),
+        )
         app_b = _make_appliance(id="high", priority=1, nominal_power=2000.0)
-        state_a = _make_state(id="low", is_on=True, current_power=1000.0,
-                              runtime_today=timedelta(minutes=30))
+        state_a = _make_state(
+            id="low",
+            is_on=True,
+            current_power=1000.0,
+            runtime_today=timedelta(minutes=30),
+        )
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["low"].action == Action.ON
         assert decisions["high"].action == Action.IDLE
@@ -1474,12 +1613,19 @@ class TestOptimizerPreemption:
         state_c = _make_state(id="high", is_on=False)
         power = _make_power(excess=2000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b, app_c],
-            appliance_states=[state_a, state_b, state_c], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b, app_c],
+            appliance_states=[state_a, state_b, state_c],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["high"].action == Action.ON
-        preempted = sum(1 for d in [decisions["low1"], decisions["low2"]] if d.action == Action.OFF)
+        preempted = sum(
+            1 for d in [decisions["low1"], decisions["low2"]] if d.action == Action.OFF
+        )
         assert preempted >= 1
 
     def test_no_preempt_not_enough_even_with_shed(self):
@@ -1490,9 +1636,14 @@ class TestOptimizerPreemption:
         state_b = _make_state(id="high", is_on=False)
         power = _make_power(excess=1000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[app_a, app_b],
-            appliance_states=[state_a, state_b], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[app_a, app_b],
+            appliance_states=[state_a, state_b],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["low"].action == Action.ON
         assert decisions["high"].action == Action.IDLE
@@ -1500,17 +1651,23 @@ class TestOptimizerPreemption:
     def test_no_preempt_dependency_protected(self):
         """Dependency-protected appliances not preempted."""
         pump = _make_appliance(id="pump", priority=5, nominal_power=1000.0)
-        heater = _make_appliance(id="heater", priority=3, nominal_power=1500.0,
-                                  requires_appliance="pump")
+        heater = _make_appliance(
+            id="heater", priority=3, nominal_power=1500.0, requires_appliance="pump"
+        )
         big = _make_appliance(id="big", priority=1, nominal_power=3000.0)
         state_pump = _make_state(id="pump", is_on=True, current_power=1000.0)
         state_heater = _make_state(id="heater", is_on=True, current_power=1500.0)
         state_big = _make_state(id="big", is_on=False)
         power = _make_power(excess=1000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
-        result = opt.optimize(power_state=power, appliances=[pump, heater, big],
-            appliance_states=[state_pump, state_heater, state_big], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff())
+        result = opt.optimize(
+            power_state=power,
+            appliances=[pump, heater, big],
+            appliance_states=[state_pump, state_heater, state_big],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["pump"].action in (Action.ON, Action.SET_CURRENT)
 
@@ -1521,28 +1678,37 @@ class TestFractionalCurrent:
     def test_step_floor_0_1(self):
         """step=0.1 preserves 6.7A as 6.7A."""
         from custom_components.pv_excess_control.optimizer import _step_floor
+
         assert _step_floor(6.7, 0.1) == pytest.approx(6.7, abs=0.01)
 
     def test_step_floor_0_5(self):
         """step=0.5 rounds 6.7A down to 6.5A."""
         from custom_components.pv_excess_control.optimizer import _step_floor
+
         assert _step_floor(6.7, 0.5) == pytest.approx(6.5, abs=0.01)
 
     def test_step_floor_1_0(self):
         """step=1.0 rounds 6.7A down to 6.0A (old integer behavior)."""
         from custom_components.pv_excess_control.optimizer import _step_floor
+
         assert _step_floor(6.7, 1.0) == pytest.approx(6.0, abs=0.01)
 
     def test_step_floor_0_3(self):
         """step=0.3 rounds 10.0A down to 9.9A."""
         from custom_components.pv_excess_control.optimizer import _step_floor
+
         assert _step_floor(10.0, 0.3) == pytest.approx(9.9, abs=0.01)
 
     def test_allocate_dynamic_fractional_current(self):
         """OFF appliance with step=0.1 gets fractional current."""
         app = _make_appliance(
-            id="charger", dynamic_current=True, current_entity="number.charger_current",
-            min_current=6.0, max_current=16.0, phases=1, nominal_power=1380,
+            id="charger",
+            dynamic_current=True,
+            current_entity="number.charger_current",
+            min_current=6.0,
+            max_current=16.0,
+            phases=1,
+            nominal_power=1380,
             current_step=0.1,
         )
         state = _make_state(id="charger", is_on=False)
@@ -1550,8 +1716,12 @@ class TestFractionalCurrent:
         power = _make_power(excess=1550.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.SET_CURRENT
@@ -1560,16 +1730,25 @@ class TestFractionalCurrent:
     def test_allocate_dynamic_step_1_gives_integer(self):
         """step=1.0 preserves old integer behavior."""
         app = _make_appliance(
-            id="charger", dynamic_current=True, current_entity="number.charger_current",
-            min_current=6.0, max_current=16.0, phases=1, nominal_power=1380,
+            id="charger",
+            dynamic_current=True,
+            current_entity="number.charger_current",
+            min_current=6.0,
+            max_current=16.0,
+            phases=1,
+            nominal_power=1380,
             current_step=1.0,
         )
         state = _make_state(id="charger", is_on=False)
         power = _make_power(excess=1550.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.SET_CURRENT
@@ -1578,8 +1757,13 @@ class TestFractionalCurrent:
     def test_shed_dynamic_fractional_current(self):
         """SHED reduces current using step size."""
         app = _make_appliance(
-            id="charger", dynamic_current=True, current_entity="number.charger_current",
-            min_current=6.0, max_current=16.0, phases=1, nominal_power=2300,
+            id="charger",
+            dynamic_current=True,
+            current_entity="number.charger_current",
+            min_current=6.0,
+            max_current=16.0,
+            phases=1,
+            nominal_power=2300,
             current_step=0.5,
         )
         state = _make_state(id="charger", is_on=True, current_power=2300.0)
@@ -1589,8 +1773,12 @@ class TestFractionalCurrent:
         power = _make_power(excess=-500.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.SET_CURRENT
@@ -1602,16 +1790,23 @@ class TestPreemptionConfig:
 
     def test_preemption_disabled_globally(self):
         """When enable_preemption=False, no preemption occurs even when it would help."""
-        app_low = _make_appliance(id="low", name="Low", priority=5, nominal_power=1000.0)
-        app_high = _make_appliance(id="high", name="High", priority=1, nominal_power=2000.0)
+        app_low = _make_appliance(
+            id="low", name="Low", priority=5, nominal_power=1000.0
+        )
+        app_high = _make_appliance(
+            id="high", name="High", priority=1, nominal_power=2000.0
+        )
         state_low = _make_state(id="low", is_on=True, current_power=1000.0)
         state_high = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230, enable_preemption=False)
         result = opt.optimize(
-            power_state=power, appliances=[app_low, app_high],
-            appliance_states=[state_low, state_high], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app_low, app_high],
+            appliance_states=[state_low, state_high],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         decisions = {d.appliance_id: d for d in result.decisions}
         # Low stays ON, high stays IDLE — no preemption
@@ -1620,16 +1815,23 @@ class TestPreemptionConfig:
 
     def test_preemption_enabled_globally(self):
         """When enable_preemption=True (default), preemption works as before."""
-        app_low = _make_appliance(id="low", name="Low", priority=5, nominal_power=1000.0)
-        app_high = _make_appliance(id="high", name="High", priority=1, nominal_power=2000.0)
+        app_low = _make_appliance(
+            id="low", name="Low", priority=5, nominal_power=1000.0
+        )
+        app_high = _make_appliance(
+            id="high", name="High", priority=1, nominal_power=2000.0
+        )
         state_low = _make_state(id="low", is_on=True, current_power=1000.0)
         state_high = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230, enable_preemption=True)
         result = opt.optimize(
-            power_state=power, appliances=[app_low, app_high],
-            appliance_states=[state_low, state_high], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app_low, app_high],
+            appliance_states=[state_low, state_high],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["high"].action == Action.ON
@@ -1638,18 +1840,26 @@ class TestPreemptionConfig:
     def test_protect_from_preemption(self):
         """Appliance with protect_from_preemption=True is never shed for higher-priority."""
         app_low = _make_appliance(
-            id="low", name="Low", priority=5, nominal_power=1000.0,
+            id="low",
+            name="Low",
+            priority=5,
+            nominal_power=1000.0,
             protect_from_preemption=True,
         )
-        app_high = _make_appliance(id="high", name="High", priority=1, nominal_power=2000.0)
+        app_high = _make_appliance(
+            id="high", name="High", priority=1, nominal_power=2000.0
+        )
         state_low = _make_state(id="low", is_on=True, current_power=1000.0)
         state_high = _make_state(id="high", is_on=False)
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230, enable_preemption=True)
         result = opt.optimize(
-            power_state=power, appliances=[app_low, app_high],
-            appliance_states=[state_low, state_high], plan=_empty_plan(),
-            power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app_low, app_high],
+            appliance_states=[state_low, state_high],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         decisions = {d.appliance_id: d for d in result.decisions}
         # Low is protected — stays ON, high stays IDLE
@@ -1659,24 +1869,37 @@ class TestPreemptionConfig:
     def test_protect_from_preemption_others_still_preemptable(self):
         """Protected appliance is skipped but unprotected ones can still be preempted."""
         app_protected = _make_appliance(
-            id="protected", name="Protected", priority=10, nominal_power=500.0,
+            id="protected",
+            name="Protected",
+            priority=10,
+            nominal_power=500.0,
             protect_from_preemption=True,
         )
         app_unprotected = _make_appliance(
-            id="unprotected", name="Unprotected", priority=8, nominal_power=1000.0,
+            id="unprotected",
+            name="Unprotected",
+            priority=8,
+            nominal_power=1000.0,
         )
-        app_high = _make_appliance(id="high", name="High", priority=1, nominal_power=2000.0)
+        app_high = _make_appliance(
+            id="high", name="High", priority=1, nominal_power=2000.0
+        )
         state_protected = _make_state(id="protected", is_on=True, current_power=500.0)
-        state_unprotected = _make_state(id="unprotected", is_on=True, current_power=1000.0)
+        state_unprotected = _make_state(
+            id="unprotected", is_on=True, current_power=1000.0
+        )
         state_high = _make_state(id="high", is_on=False)
         # 1500W excess: not enough for 2000W high-priority.
         # Unprotected frees 1000W -> 1500+1000=2500 >= 2200 (2000+200 threshold) -> preempt
         power = _make_power(excess=1500.0)
         opt = _optimizer_for_tests(grid_voltage=230, enable_preemption=True)
         result = opt.optimize(
-            power_state=power, appliances=[app_protected, app_unprotected, app_high],
+            power_state=power,
+            appliances=[app_protected, app_unprotected, app_high],
             appliance_states=[state_protected, state_unprotected, state_high],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         decisions = {d.appliance_id: d for d in result.decisions}
         assert decisions["high"].action == Action.ON
@@ -1694,8 +1917,12 @@ class TestMaxDailyActivations:
         power = _make_power(excess=2000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.IDLE
@@ -1708,8 +1935,12 @@ class TestMaxDailyActivations:
         power = _make_power(excess=2000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.ON
@@ -1717,25 +1948,37 @@ class TestMaxDailyActivations:
     def test_on_appliance_at_max_activations_stays_on(self):
         """ON appliance at max activations is NOT affected — stays ON."""
         app = _make_appliance(id="pump", nominal_power=1000.0, max_daily_activations=3)
-        state = _make_state(id="pump", is_on=True, current_power=1000.0, activations_today=3)
+        state = _make_state(
+            id="pump", is_on=True, current_power=1000.0, activations_today=3
+        )
         power = _make_power(excess=2000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.ON
 
     def test_no_limit_when_max_activations_none(self):
         """max_daily_activations=None means unlimited — no limit applied."""
-        app = _make_appliance(id="pump", nominal_power=1000.0, max_daily_activations=None)
+        app = _make_appliance(
+            id="pump", nominal_power=1000.0, max_daily_activations=None
+        )
         state = _make_state(id="pump", is_on=False, activations_today=999)
         power = _make_power(excess=2000.0)
         opt = _optimizer_for_tests(grid_voltage=230)
         result = opt.optimize(
-            power_state=power, appliances=[app], appliance_states=[state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[app],
+            appliance_states=[state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
         d = result.decisions[0]
         assert d.action == Action.ON
@@ -1744,6 +1987,7 @@ class TestMaxDailyActivations:
 # ---------------------------------------------------------------------------
 # TestOnThreshold
 # ---------------------------------------------------------------------------
+
 
 class TestOnThreshold:
     """Tests for per-appliance activation buffer (on_threshold)."""
@@ -1885,6 +2129,7 @@ class TestOnThreshold:
 # TestOffThreshold
 # ---------------------------------------------------------------------------
 
+
 class TestOffThreshold:
     """Tests for global configurable shed threshold (off_threshold)."""
 
@@ -1966,28 +2211,40 @@ class TestBypassesCooldownFlag:
         from datetime import timedelta as td
 
         from custom_components.pv_excess_control.models import (
-            BatteryTarget, BatteryStrategy, Plan, PowerState, TariffInfo,
+            BatteryTarget,
+            BatteryStrategy,
+            Plan,
+            PowerState,
+            TariffInfo,
         )
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         power_state = PowerState(
-            pv_production=3000, grid_export=0, grid_import=0,
-            load_power=500, excess_power=2500,
-            battery_soc=None, battery_power=None, ev_soc=None,
+            pv_production=3000,
+            grid_export=0,
+            grid_import=0,
+            load_power=500,
+            excess_power=2500,
+            battery_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 12, 0, 0),
         )
         plan = Plan(
             created_at=datetime(2026, 4, 6, 11, 0, 0),
-            horizon=td(hours=8), entries=[],
+            horizon=td(hours=8),
+            entries=[],
             battery_target=BatteryTarget(
-                target_soc=80, target_time=datetime(2026, 4, 6, 18, 0, 0),
+                target_soc=80,
+                target_time=datetime(2026, 4, 6, 18, 0, 0),
                 strategy=BatteryStrategy.BALANCED,
             ),
             confidence=0.75,
         )
         tariff = TariffInfo(
-            current_price=0.20, feed_in_tariff=0.08,
-            cheap_price_threshold=0.15, battery_charge_price_threshold=0.10,
+            current_price=0.20,
+            feed_in_tariff=0.08,
+            cheap_price_threshold=0.15,
+            battery_charge_price_threshold=0.10,
         )
         return {
             "optimizer": _optimizer_for_tests(),
@@ -2000,17 +2257,28 @@ class TestBypassesCooldownFlag:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         defaults = dict(
-            id="app1", name="Test", entity_id="switch.test",
-            priority=100, phases=1, nominal_power=1000.0, actual_power_entity=None,
-            dynamic_current=False, current_entity=None,
-            min_current=6.0, max_current=16.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
+            id="app1",
+            name="Test",
+            entity_id="switch.test",
+            priority=100,
+            phases=1,
+            nominal_power=1000.0,
+            actual_power_entity=None,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=6.0,
+            max_current=16.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
             on_only=False,
-            min_daily_runtime=None, max_daily_runtime=None,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
             schedule_deadline=None,
             switch_interval=300,
-            allow_grid_supplement=False, max_grid_power=None,
+            allow_grid_supplement=False,
+            max_grid_power=None,
         )
         defaults.update(overrides)
         return ApplianceConfig(**defaults)
@@ -2111,6 +2379,7 @@ class TestBypassesCooldownFlag:
             assert decision.bypasses_cooldown is True
         else:
             import pytest
+
             pytest.skip(
                 "Wall-clock is within the configured 03:00-04:00 window; "
                 "outside-window branch not exercised."
@@ -2119,17 +2388,20 @@ class TestBypassesCooldownFlag:
     def test_battery_soc_protection_sets_flag(self) -> None:
         from custom_components.pv_excess_control.const import Action
         from custom_components.pv_excess_control.models import PowerState
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         appliance = self._make_appliance()
         state = self._make_state(is_on=True, current_power=500.0)
         ctx = self._base_ctx()
         # Override power_state to include a battery_soc below threshold
         power_state = PowerState(
-            pv_production=3000, grid_export=0, grid_import=0,
-            load_power=500, excess_power=2500,
+            pv_production=3000,
+            grid_export=0,
+            grid_import=0,
+            load_power=500,
+            excess_power=2500,
             battery_soc=25.0,  # below 30% min
-            battery_power=None, ev_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 12, 0, 0),
         )
         result = ctx["optimizer"].optimize(
@@ -2170,9 +2442,14 @@ class TestBypassesCooldownFlag:
         ctx = self._base_ctx()
         # Override power_state to zero excess so allocation fails
         zero_excess = PowerState(
-            pv_production=500, grid_export=0, grid_import=0,
-            load_power=500, excess_power=0,
-            battery_soc=None, battery_power=None, ev_soc=None,
+            pv_production=500,
+            grid_export=0,
+            grid_import=0,
+            load_power=500,
+            excess_power=0,
+            battery_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 12, 0, 0),
         )
         result = ctx["optimizer"].optimize(
@@ -2196,22 +2473,38 @@ class TestAlreadyOnReasonStrings:
         from datetime import timedelta as td
 
         from custom_components.pv_excess_control.models import (
-            ApplianceConfig, ApplianceState, BatteryTarget, BatteryStrategy,
-            Plan, PowerState, TariffInfo,
+            ApplianceConfig,
+            ApplianceState,
+            BatteryTarget,
+            BatteryStrategy,
+            Plan,
+            PowerState,
+            TariffInfo,
         )
 
         appliance = ApplianceConfig(
-            id="app1", name="Test", entity_id="switch.test",
-            priority=100, phases=1, nominal_power=2000.0, actual_power_entity=None,
-            dynamic_current=False, current_entity=None,
-            min_current=6.0, max_current=16.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
+            id="app1",
+            name="Test",
+            entity_id="switch.test",
+            priority=100,
+            phases=1,
+            nominal_power=2000.0,
+            actual_power_entity=None,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=6.0,
+            max_current=16.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
             on_only=False,
-            min_daily_runtime=None, max_daily_runtime=None,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
             schedule_deadline=None,
             switch_interval=300,
-            allow_grid_supplement=False, max_grid_power=None,
+            allow_grid_supplement=False,
+            max_grid_power=None,
         )
         state = ApplianceState(
             appliance_id="app1",
@@ -2224,31 +2517,42 @@ class TestAlreadyOnReasonStrings:
             ev_connected=None,
         )
         power_state = PowerState(
-            pv_production=3000, grid_export=0, grid_import=0,
-            load_power=2340, excess_power=720,
-            battery_soc=None, battery_power=None, ev_soc=None,
+            pv_production=3000,
+            grid_export=0,
+            grid_import=0,
+            load_power=2340,
+            excess_power=720,
+            battery_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 12, 0, 0),
         )
         plan = Plan(
             created_at=datetime(2026, 4, 6, 11, 0, 0),
-            horizon=td(hours=8), entries=[],
+            horizon=td(hours=8),
+            entries=[],
             battery_target=BatteryTarget(
-                target_soc=80, target_time=datetime(2026, 4, 6, 18, 0, 0),
+                target_soc=80,
+                target_time=datetime(2026, 4, 6, 18, 0, 0),
                 strategy=BatteryStrategy.BALANCED,
             ),
             confidence=0.75,
         )
         tariff = TariffInfo(
-            current_price=0.20, feed_in_tariff=0.08,
-            cheap_price_threshold=0.15, battery_charge_price_threshold=0.10,
+            current_price=0.20,
+            feed_in_tariff=0.08,
+            cheap_price_threshold=0.15,
+            battery_charge_price_threshold=0.10,
         )
         return {
-            "appliance": appliance, "state": state,
-            "power_state": power_state, "plan": plan, "tariff": tariff,
+            "appliance": appliance,
+            "state": state,
+            "power_state": power_state,
+            "plan": plan,
+            "tariff": tariff,
         }
 
     def test_standard_appliance_already_on_shows_headroom(self) -> None:
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         kwargs = self._base_kwargs()
         opt = _optimizer_for_tests(off_threshold=-100)
@@ -2268,24 +2572,34 @@ class TestAlreadyOnReasonStrings:
     def test_dynamic_appliance_already_on_shows_amps_and_headroom(self) -> None:
         from datetime import timedelta as td
         from custom_components.pv_excess_control.models import (
-            ApplianceConfig, ApplianceState,
+            ApplianceConfig,
+            ApplianceState,
         )
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         kwargs = self._base_kwargs()
         dyn = ApplianceConfig(
-            id="app1", name="EV", entity_id="switch.ev",
-            priority=100, phases=3, nominal_power=11000.0,
+            id="app1",
+            name="EV",
+            entity_id="switch.ev",
+            priority=100,
+            phases=3,
+            nominal_power=11000.0,
             actual_power_entity=None,
-            dynamic_current=True, current_entity="number.ev_current",
-            min_current=6.0, max_current=16.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
+            dynamic_current=True,
+            current_entity="number.ev_current",
+            min_current=6.0,
+            max_current=16.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
             on_only=False,
-            min_daily_runtime=None, max_daily_runtime=None,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
             schedule_deadline=None,
             switch_interval=300,
-            allow_grid_supplement=False, max_grid_power=None,
+            allow_grid_supplement=False,
+            max_grid_power=None,
         )
         state = ApplianceState(
             appliance_id="app1",
@@ -2301,10 +2615,16 @@ class TestAlreadyOnReasonStrings:
         # Use off_threshold=-5000 so SHED doesn't fire at excess=-3000W
         # available = -3000 + 6900 = 3900 < 4140 → target < min_current → "staying on" branch
         from custom_components.pv_excess_control.models import PowerState
+
         tiny_excess = PowerState(
-            pv_production=3900, grid_export=0, grid_import=0,
-            load_power=6900, excess_power=-3000,
-            battery_soc=None, battery_power=None, ev_soc=None,
+            pv_production=3900,
+            grid_export=0,
+            grid_import=0,
+            load_power=6900,
+            excess_power=-3000,
+            battery_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 12, 0, 0),
         )
         opt = _optimizer_for_tests(off_threshold=-5000)
@@ -2344,9 +2664,7 @@ class TestStayingOnHelpersDirect:
             off_threshold=-100,
             instant_budget=720,
         )
-        assert text == (
-            "Staying on (2340W drawn) - shed at -100W (current: +720W)"
-        )
+        assert text == ("Staying on (2340W drawn) - shed at -100W (current: +720W)")
 
     def test_standard_shed_imminent_when_remaining_below_threshold(self) -> None:
         from custom_components.pv_excess_control.optimizer import (
@@ -2387,8 +2705,7 @@ class TestStayingOnHelpersDirect:
             instant_budget=720,
         )
         assert text == (
-            "Staying on at 10.0A (6900W drawn) - "
-            "shed at -100W (current: +720W)"
+            "Staying on at 10.0A (6900W drawn) - shed at -100W (current: +720W)"
         )
 
     def test_dynamic_shed_imminent(self) -> None:
@@ -2417,9 +2734,7 @@ class TestStayingOnHelpersDirect:
             instant_budget=720,
         )
         # No amperage prefix → standard format
-        assert text == (
-            "Staying on (2340W drawn) - shed at -100W (current: +720W)"
-        )
+        assert text == ("Staying on (2340W drawn) - shed at -100W (current: +720W)")
         assert "A " not in text  # no amperage prefix
 
 
@@ -2441,12 +2756,18 @@ class TestDeadlineReasonStrings:
         from datetime import timedelta as td, time
 
         from custom_components.pv_excess_control.models import (
-            ApplianceConfig, ApplianceState, BatteryTarget, BatteryStrategy,
-            Plan, PowerState, TariffInfo,
+            ApplianceConfig,
+            ApplianceState,
+            BatteryTarget,
+            BatteryStrategy,
+            Plan,
+            PowerState,
+            TariffInfo,
         )
 
         appliance = ApplianceConfig(
-            id="app1", name="Pool",
+            id="app1",
+            name="Pool",
             entity_id="switch.pool",
             priority=100,
             phases=3 if dynamic else 1,
@@ -2454,9 +2775,12 @@ class TestDeadlineReasonStrings:
             actual_power_entity=None,
             dynamic_current=dynamic,
             current_entity=("number.ev_current" if dynamic else None),
-            min_current=6.0, max_current=16.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
+            min_current=6.0,
+            max_current=16.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
             on_only=False,
             # Oversized so `remaining_runtime * 1.1` always covers
             # `time_until_deadline` (<= 86400s) regardless of wall time
@@ -2464,7 +2788,8 @@ class TestDeadlineReasonStrings:
             max_daily_runtime=None,
             schedule_deadline=time(14, 0),
             switch_interval=300,
-            allow_grid_supplement=False, max_grid_power=None,
+            allow_grid_supplement=False,
+            max_grid_power=None,
         )
         state = ApplianceState(
             appliance_id="app1",
@@ -2479,27 +2804,39 @@ class TestDeadlineReasonStrings:
         # Force insufficient excess so the allocator falls through to the
         # deadline must-run branch.
         power_state = PowerState(
-            pv_production=200, grid_export=0, grid_import=800,
-            load_power=1000, excess_power=-800,
-            battery_soc=None, battery_power=None, ev_soc=None,
+            pv_production=200,
+            grid_export=0,
+            grid_import=800,
+            load_power=1000,
+            excess_power=-800,
+            battery_soc=None,
+            battery_power=None,
+            ev_soc=None,
             timestamp=datetime(2026, 4, 6, 13, 0, 0),
         )
         plan = Plan(
             created_at=datetime(2026, 4, 6, 11, 0, 0),
-            horizon=td(hours=8), entries=[],
+            horizon=td(hours=8),
+            entries=[],
             battery_target=BatteryTarget(
-                target_soc=80, target_time=datetime(2026, 4, 6, 18, 0, 0),
+                target_soc=80,
+                target_time=datetime(2026, 4, 6, 18, 0, 0),
                 strategy=BatteryStrategy.BALANCED,
             ),
             confidence=0.75,
         )
         tariff = TariffInfo(
-            current_price=0.20, feed_in_tariff=0.08,
-            cheap_price_threshold=0.15, battery_charge_price_threshold=0.10,
+            current_price=0.20,
+            feed_in_tariff=0.08,
+            cheap_price_threshold=0.15,
+            battery_charge_price_threshold=0.10,
         )
         return {
-            "appliance": appliance, "state": state,
-            "power_state": power_state, "plan": plan, "tariff": tariff,
+            "appliance": appliance,
+            "state": state,
+            "power_state": power_state,
+            "plan": plan,
+            "tariff": tariff,
         }
 
     def _assert_new_deadline_format(self, reason: str) -> None:
@@ -2518,7 +2855,6 @@ class TestDeadlineReasonStrings:
 
     def test_standard_deadline_has_human_readable_format(self) -> None:
         """non-dynamic deadline must-run path."""
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         fx = self._build_fixture(dynamic=False)
         opt = _optimizer_for_tests()
@@ -2535,7 +2871,6 @@ class TestDeadlineReasonStrings:
 
     def test_dynamic_deadline_has_human_readable_format(self) -> None:
         """dynamic current deadline must-run path."""
-        from custom_components.pv_excess_control.optimizer import Optimizer
 
         fx = self._build_fixture(dynamic=True)
         opt = _optimizer_for_tests()
@@ -2555,14 +2890,12 @@ class TestDeadlineReasonStrings:
         treats it as tomorrow and the reason string says so."""
         from datetime import time
 
-        from custom_components.pv_excess_control.optimizer import Optimizer
-
         fx = self._build_fixture(dynamic=False)
         # Override schedule_deadline to 00:00 — guaranteed to be ≤ any
         # current wall-clock time, so the overnight branch always fires.
         appliance = fx["appliance"]
-        from custom_components.pv_excess_control.models import ApplianceConfig
         from dataclasses import replace
+
         midnight_appliance = replace(appliance, schedule_deadline=time(0, 0))
 
         opt = _optimizer_for_tests()
@@ -2586,6 +2919,7 @@ class TestDeadlineReasonStrings:
 # TestDeadlineMustRunShedProtection
 # ---------------------------------------------------------------------------
 
+
 class TestDeadlineMustRunShedProtection:
     """Deadline must-run decisions bypass cooldown and are excluded from SHED."""
 
@@ -2598,9 +2932,16 @@ class TestDeadlineMustRunShedProtection:
         )
         from dataclasses import replace
         from datetime import time as dt_time
-        appliance = replace(appliance, schedule_deadline=dt_time(14, 0), min_daily_runtime=timedelta(hours=25))
 
-        state = _make_state(id="heater", is_on=False, current_power=0.0, runtime_today=timedelta())
+        appliance = replace(
+            appliance,
+            schedule_deadline=dt_time(14, 0),
+            min_daily_runtime=timedelta(hours=25),
+        )
+
+        state = _make_state(
+            id="heater", is_on=False, current_power=0.0, runtime_today=timedelta()
+        )
         power = _make_power(excess=-800.0)
         opt = _optimizer_for_tests()
         result = opt.optimize(
@@ -2630,9 +2971,16 @@ class TestDeadlineMustRunShedProtection:
         )
         from dataclasses import replace
         from datetime import time as dt_time
-        appliance = replace(appliance, schedule_deadline=dt_time(14, 0), min_daily_runtime=timedelta(hours=25))
 
-        state = _make_state(id="ev", is_on=False, current_power=0.0, runtime_today=timedelta())
+        appliance = replace(
+            appliance,
+            schedule_deadline=dt_time(14, 0),
+            min_daily_runtime=timedelta(hours=25),
+        )
+
+        state = _make_state(
+            id="ev", is_on=False, current_power=0.0, runtime_today=timedelta()
+        )
         power = _make_power(excess=-800.0)
         opt = _optimizer_for_tests()
         result = opt.optimize(
@@ -2662,12 +3010,21 @@ class TestDeadlineMustRunShedProtection:
         )
         from dataclasses import replace
         from datetime import time as dt_time
-        heater = replace(heater, schedule_deadline=dt_time(14, 0), min_daily_runtime=timedelta(hours=25))
+
+        heater = replace(
+            heater,
+            schedule_deadline=dt_time(14, 0),
+            min_daily_runtime=timedelta(hours=25),
+        )
 
         lamp = _make_appliance(id="lamp", nominal_power=200.0, priority=5)
 
-        heater_state = _make_state(id="heater", is_on=False, current_power=0.0, runtime_today=timedelta())
-        lamp_state = _make_state(id="lamp", is_on=True, current_power=200.0, runtime_today=timedelta(hours=1))
+        heater_state = _make_state(
+            id="heater", is_on=False, current_power=0.0, runtime_today=timedelta()
+        )
+        lamp_state = _make_state(
+            id="lamp", is_on=True, current_power=200.0, runtime_today=timedelta(hours=1)
+        )
 
         power = _make_power(excess=-5000.0)
         opt = _optimizer_for_tests()
@@ -2692,6 +3049,7 @@ class TestDeadlineMustRunShedProtection:
 # ---------------------------------------------------------------------------
 # TestCalculateAverageExcess
 # ---------------------------------------------------------------------------
+
 
 class TestCalculateAverageExcess:
     """Phase 1 ASSESS buffer filtering + min-sample threshold.
@@ -2795,6 +3153,7 @@ class TestCalculateAverageExcess:
 # TestSafetyOnlyPath
 # ---------------------------------------------------------------------------
 
+
 class TestSafetyOnlyPath:
     """Optimizer behaviour when Phase 1 ASSESS returns None.
 
@@ -2806,9 +3165,14 @@ class TestSafetyOnlyPath:
 
     def _none_excess_power_state(self) -> PowerState:
         return PowerState(
-            pv_production=None, grid_export=None, grid_import=None,
-            load_power=None, excess_power=None,
-            battery_soc=50.0, battery_power=0.0, ev_soc=None,
+            pv_production=None,
+            grid_export=None,
+            grid_import=None,
+            load_power=None,
+            excess_power=None,
+            battery_soc=50.0,
+            battery_power=0.0,
+            ev_soc=None,
             timestamp=datetime.now(),
         )
 
@@ -2818,19 +3182,27 @@ class TestSafetyOnlyPath:
     def test_optimizer_none_excess_runs_safety_only(self):
         """An appliance past max_daily_runtime still gets OFF; no allocations fire."""
         laundry = _make_appliance(
-            id="laundry", priority=500, nominal_power=2000.0,
+            id="laundry",
+            priority=500,
+            nominal_power=2000.0,
             max_daily_runtime=None,
         )
         pool = _make_appliance(
-            id="pool", priority=600, nominal_power=1500.0,
+            id="pool",
+            priority=600,
+            nominal_power=1500.0,
             max_daily_runtime=timedelta(hours=2),
         )
         laundry_state = _make_state(
-            id="laundry", is_on=False, current_power=0.0,
+            id="laundry",
+            is_on=False,
+            current_power=0.0,
             runtime_today=timedelta(0),
         )
         pool_state = _make_state(
-            id="pool", is_on=True, current_power=1500.0,
+            id="pool",
+            is_on=True,
+            current_power=1500.0,
             runtime_today=timedelta(hours=3),  # past the limit
         )
 
@@ -2850,23 +3222,34 @@ class TestSafetyOnlyPath:
 
         assert not any(
             d.action in (Action.ON, Action.SET_CURRENT)
-            for d in result.decisions if d.appliance_id == "laundry"
+            for d in result.decisions
+            if d.appliance_id == "laundry"
         ), "laundry should not be allocated in the safety-only path"
 
     def test_optimizer_none_excess_phase4_still_runs(self):
         """Phase 4 (battery discharge protection) runs even when excess is None."""
         big = _make_appliance(
-            id="ev", priority=500, nominal_power=7000.0,
-            is_big_consumer=True, battery_max_discharge_override=500.0,
+            id="ev",
+            priority=500,
+            nominal_power=7000.0,
+            is_big_consumer=True,
+            battery_max_discharge_override=500.0,
         )
         big_state = _make_state(
-            id="ev", is_on=True, current_power=7000.0,
+            id="ev",
+            is_on=True,
+            current_power=7000.0,
             runtime_today=timedelta(0),
         )
         ps = PowerState(
-            pv_production=None, grid_export=None, grid_import=None,
-            load_power=None, excess_power=None,
-            battery_soc=15.0, battery_power=-1000.0, ev_soc=None,
+            pv_production=None,
+            grid_export=None,
+            grid_import=None,
+            load_power=None,
+            excess_power=None,
+            battery_soc=15.0,
+            battery_power=-1000.0,
+            ev_soc=None,
             timestamp=datetime.now(),
         )
 
@@ -2889,11 +3272,16 @@ class TestSafetyOnlyPath:
     def test_optimizer_none_excess_already_on_appliance_stays_on(self):
         """Currently-ON appliance with no safety rule firing: no OFF from Phase 3."""
         app = _make_appliance(
-            id="dishwasher", priority=500, nominal_power=2000.0,
-            max_daily_runtime=None, on_only=False,
+            id="dishwasher",
+            priority=500,
+            nominal_power=2000.0,
+            max_daily_runtime=None,
+            on_only=False,
         )
         state = _make_state(
-            id="dishwasher", is_on=True, current_power=2000.0,
+            id="dishwasher",
+            is_on=True,
+            current_power=2000.0,
             runtime_today=timedelta(minutes=30),
         )
 
@@ -2915,6 +3303,7 @@ class TestSafetyOnlyPath:
 # TestHelperOnlyMode
 # ---------------------------------------------------------------------------
 
+
 class TestHelperOnlyMode:
     """Test helper-only appliance mode (Phase 2 short-circuit + sort order)."""
 
@@ -2928,8 +3317,12 @@ class TestHelperOnlyMode:
         # Helper has HIGHER priority (lower number) than its dependent.
         # Without the helper_only sort key it would sort first; with it,
         # it must sort last.
-        helper = _make_appliance(id="helper", priority=100, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=500, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=100, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=500, requires_appliance="helper", nominal_power=1500.0
+        )
         # An unrelated non-helper that should sort by priority normally.
         other = _make_appliance(id="other", priority=300, nominal_power=800.0)
 
@@ -2963,8 +3356,12 @@ class TestHelperOnlyMode:
         helper_state = _make_state(id="helper")
         power = _make_power(excess=1000.0)
         optimizer.optimize(
-            power_state=power, appliances=[helper], appliance_states=[helper_state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            power_state=power,
+            appliances=[helper],
+            appliance_states=[helper_state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
 
         # Now query the helper method directly with empty inputs.
@@ -2981,15 +3378,21 @@ class TestHelperOnlyMode:
 
         # Run optimize once so reverse_deps map is populated.
         optimizer.optimize(
-            power_state=power, appliances=[helper, dependent],
+            power_state=power,
+            appliances=[helper, dependent],
             appliance_states=[helper_state, dep_state],
-            plan=_empty_plan(), power_history=[power], tariff=_make_tariff(),
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.ON, target_current=None,
-                reason="test", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.ON,
+                target_current=None,
+                reason="test",
+                overrides_plan=False,
             ),
         ]
         assert optimizer._has_running_dependent("helper", decisions, {}) is True
@@ -3003,14 +3406,18 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.SET_CURRENT, target_current=10.0,
-                reason="test", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.SET_CURRENT,
+                target_current=10.0,
+                reason="test",
+                overrides_plan=False,
             ),
         ]
         assert optimizer._has_running_dependent("helper", decisions, {}) is True
@@ -3024,14 +3431,18 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.OFF, target_current=None,
-                reason="test", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.OFF,
+                target_current=None,
+                reason="test",
+                overrides_plan=False,
             ),
         ]
         assert optimizer._has_running_dependent("helper", decisions, {}) is False
@@ -3046,7 +3457,8 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
@@ -3069,7 +3481,8 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
@@ -3082,8 +3495,12 @@ class TestHelperOnlyMode:
     def test_helper_idle_when_no_dependent_running(self):
         """Helper currently OFF, no dependent running -> IDLE."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         # Dependent has no excess to start (excess = 0)
         power = _make_power(excess=0.0)
         result = optimizer.optimize(
@@ -3097,13 +3514,20 @@ class TestHelperOnlyMode:
 
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         assert helper_dec.action == Action.IDLE
-        assert "no dependent" in helper_dec.reason.lower() or "helper-only" in helper_dec.reason.lower()
+        assert (
+            "no dependent" in helper_dec.reason.lower()
+            or "helper-only" in helper_dec.reason.lower()
+        )
 
     def test_helper_off_when_currently_on_and_no_dependent(self):
         """Helper currently ON, no dependent running -> OFF (mirror semantics)."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         # Helper is on, dependent is not
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=False)
@@ -3119,13 +3543,20 @@ class TestHelperOnlyMode:
 
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         assert helper_dec.action == Action.OFF
-        assert "no dependent" in helper_dec.reason.lower() or "helper-only" in helper_dec.reason.lower()
+        assert (
+            "no dependent" in helper_dec.reason.lower()
+            or "helper-only" in helper_dec.reason.lower()
+        )
 
     def test_helper_on_when_dependent_starts(self):
         """Helper OFF, dependent transitions OFF->ON in same cycle -> helper ON."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         # Excess = 2000W, enough for dep (1500) + helper (200) + buffer
         power = _make_power(excess=2000.0)
         result = optimizer.optimize(
@@ -3139,15 +3570,23 @@ class TestHelperOnlyMode:
 
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         dep_dec = next(d for d in result.decisions if d.appliance_id == "dep")
-        assert dep_dec.action == Action.ON, f"dep should be ON, got {dep_dec.action} ({dep_dec.reason})"
-        assert helper_dec.action == Action.ON, f"helper should be ON, got {helper_dec.action} ({helper_dec.reason})"
+        assert dep_dec.action == Action.ON, (
+            f"dep should be ON, got {dep_dec.action} ({dep_dec.reason})"
+        )
+        assert helper_dec.action == Action.ON, (
+            f"helper should be ON, got {helper_dec.action} ({helper_dec.reason})"
+        )
         assert "helper-only" in helper_dec.reason.lower()
 
     def test_helper_stays_on_when_dependent_already_running(self):
         """Helper ON, dependent ON and staying ON -> helper stays ON."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
         # Excess after subtracting these: assume 500W spare
@@ -3170,15 +3609,22 @@ class TestHelperOnlyMode:
     def test_helper_off_when_dependent_stops(self):
         """Helper ON, dependent transitions ON->OFF (max_daily_runtime hit) -> both OFF."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
         # Dependent has hit its max_daily_runtime
         dependent = _make_appliance(
-            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0,
+            id="dep",
+            priority=400,
+            requires_appliance="helper",
+            nominal_power=1500.0,
             max_daily_runtime=timedelta(minutes=60),
         )
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(
-            id="dep", is_on=True, current_power=1500.0,
+            id="dep",
+            is_on=True,
+            current_power=1500.0,
             runtime_today=timedelta(minutes=120),  # Already over the limit
         )
         power = _make_power(excess=2000.0)
@@ -3193,15 +3639,25 @@ class TestHelperOnlyMode:
 
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         dep_dec = next(d for d in result.decisions if d.appliance_id == "dep")
-        assert dep_dec.action == Action.OFF, f"dep should be OFF (max_daily_runtime), got {dep_dec.reason}"
-        assert helper_dec.action == Action.OFF, f"helper should mirror dep OFF, got {helper_dec.reason}"
+        assert dep_dec.action == Action.OFF, (
+            f"dep should be OFF (max_daily_runtime), got {dep_dec.reason}"
+        )
+        assert helper_dec.action == Action.OFF, (
+            f"helper should mirror dep OFF, got {helper_dec.reason}"
+        )
 
     def test_helper_with_multiple_dependents_one_running(self):
         """Helper has 2 dependents, one ON one OFF -> helper stays ON."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dep1 = _make_appliance(id="dep1", priority=400, requires_appliance="helper", nominal_power=1500.0)
-        dep2 = _make_appliance(id="dep2", priority=410, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dep1 = _make_appliance(
+            id="dep1", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
+        dep2 = _make_appliance(
+            id="dep2", priority=410, requires_appliance="helper", nominal_power=1500.0
+        )
 
         # dep1 is ON, dep2 is OFF
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
@@ -3227,9 +3683,15 @@ class TestHelperOnlyMode:
     def test_helper_with_multiple_dependents_all_off(self):
         """Helper has 2 dependents, both OFF -> helper OFF."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dep1 = _make_appliance(id="dep1", priority=400, requires_appliance="helper", nominal_power=1500.0)
-        dep2 = _make_appliance(id="dep2", priority=410, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dep1 = _make_appliance(
+            id="dep1", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
+        dep2 = _make_appliance(
+            id="dep2", priority=410, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep1_state = _make_state(id="dep1", is_on=False)
@@ -3252,10 +3714,15 @@ class TestHelperOnlyMode:
         """Helper with override_active=True runs regardless of dependent state."""
         optimizer = _optimizer_for_tests()
         helper = _make_appliance(
-            id="helper", priority=500, helper_only=True,
-            nominal_power=200.0, override_active=True,
+            id="helper",
+            priority=500,
+            helper_only=True,
+            nominal_power=200.0,
+            override_active=True,
         )
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=False)
         dep_state = _make_state(id="dep", is_on=False)
@@ -3280,8 +3747,12 @@ class TestHelperOnlyMode:
         """Helper currently ON (physical button) with no override and no
         dependent -> integration emits OFF (A-strict semantics)."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         # Helper physically ON (e.g., user hit the button), dependent OFF
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
@@ -3298,21 +3769,31 @@ class TestHelperOnlyMode:
 
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         assert helper_dec.action == Action.OFF
-        assert "no dependent" in helper_dec.reason.lower() or "helper-only" in helper_dec.reason.lower()
+        assert (
+            "no dependent" in helper_dec.reason.lower()
+            or "helper-only" in helper_dec.reason.lower()
+        )
 
     def test_helper_max_daily_runtime_overrides_helper_only(self):
         """Helper with max_daily_runtime exceeded is OFF even when dependent
         wants to start. max_daily_runtime sits earlier in the safety chain."""
         optimizer = _optimizer_for_tests()
         helper = _make_appliance(
-            id="helper", priority=500, helper_only=True, nominal_power=200.0,
+            id="helper",
+            priority=500,
+            helper_only=True,
+            nominal_power=200.0,
             max_daily_runtime=timedelta(minutes=60),
         )
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         # Helper has hit its max runtime
         helper_state = _make_state(
-            id="helper", is_on=True, current_power=200.0,
+            id="helper",
+            is_on=True,
+            current_power=200.0,
             runtime_today=timedelta(minutes=120),
         )
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3329,7 +3810,10 @@ class TestHelperOnlyMode:
         helper_dec = next(d for d in result.decisions if d.appliance_id == "helper")
         assert helper_dec.action == Action.OFF
         # Reason should mention max_daily_runtime, not helper-only
-        assert "max_daily_runtime" in helper_dec.reason.lower() or "max daily runtime" in helper_dec.reason.lower()
+        assert (
+            "max_daily_runtime" in helper_dec.reason.lower()
+            or "max daily runtime" in helper_dec.reason.lower()
+        )
 
     def test_helper_ignores_time_window(self):
         """Helper has start_after=22:00 / end_before=23:00, current time
@@ -3342,15 +3826,21 @@ class TestHelperOnlyMode:
         """
         from datetime import time as dtime
         from dataclasses import replace
+
         optimizer = _optimizer_for_tests()
         helper = _make_appliance(
-            id="helper", priority=500, helper_only=True, nominal_power=200.0,
+            id="helper",
+            priority=500,
+            helper_only=True,
+            nominal_power=200.0,
         )
         # Override start_after / end_before via direct construction since the
         # _make_appliance factory doesn't expose them. Use dataclasses.replace.
         helper = replace(helper, start_after=dtime(22, 0), end_before=dtime(23, 0))
 
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=False)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3375,10 +3865,15 @@ class TestHelperOnlyMode:
         (helper-only short-circuit sits before on_only check)."""
         optimizer = _optimizer_for_tests()
         helper = _make_appliance(
-            id="helper", priority=500, helper_only=True, on_only=True,
+            id="helper",
+            priority=500,
+            helper_only=True,
+            on_only=True,
             nominal_power=200.0,
         )
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=False)
@@ -3396,15 +3891,22 @@ class TestHelperOnlyMode:
         # No dependent running — helper-only short-circuit fires before on_only,
         # so helper goes OFF (mirror semantics) instead of staying ON.
         assert helper_dec.action == Action.OFF
-        assert "helper-only" in helper_dec.reason.lower() or "no dependent" in helper_dec.reason.lower()
+        assert (
+            "helper-only" in helper_dec.reason.lower()
+            or "no dependent" in helper_dec.reason.lower()
+        )
 
     def test_helper_safety_only_path_steady_state(self):
         """Safety-only path: helper currently ON, dependent currently ON,
         no safety rule fires for dependent -> helper stays ON via state fallback."""
         # Use min_good_samples=3 to force safety-only path with only 1 sample
         optimizer = _optimizer_for_tests(min_good_samples=3)
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3423,21 +3925,35 @@ class TestHelperOnlyMode:
         # In safety-only path, dependents with no firing safety rule are
         # OMITTED from decisions. The helper-only short-circuit should fall
         # back to checking dep_state.is_on -> True -> helper ON.
-        helper_dec = next((d for d in result.decisions if d.appliance_id == "helper"), None)
-        assert helper_dec is not None, "helper should have a decision in safety-only path"
+        helper_dec = next(
+            (d for d in result.decisions if d.appliance_id == "helper"), None
+        )
+        assert helper_dec is not None, (
+            "helper should have a decision in safety-only path"
+        )
         assert helper_dec.action == Action.ON
-        assert "helper-only" in helper_dec.reason.lower() or "dependent is running" in helper_dec.reason.lower()
+        assert (
+            "helper-only" in helper_dec.reason.lower()
+            or "dependent is running" in helper_dec.reason.lower()
+        )
 
     def test_helper_safety_only_path_dependent_safety_off(self):
         """Safety-only path: helper currently ON, dependent has time window
         forcing OFF -> helper sees dependent OFF in decisions -> helper OFF."""
         from datetime import time as dtime
         from dataclasses import replace
+
         optimizer = _optimizer_for_tests(min_good_samples=3)
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         # Restrict dependent to a time window that excludes the test fixture time (12:00 UTC)
-        dependent = replace(dependent, start_after=dtime(22, 0), end_before=dtime(23, 0))
+        dependent = replace(
+            dependent, start_after=dtime(22, 0), end_before=dtime(23, 0)
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3454,22 +3970,31 @@ class TestHelperOnlyMode:
 
         # Dependent should have an OFF decision in the list (time window
         # safety rule fired). Helper should see that and emit OFF.
-        helper_dec = next((d for d in result.decisions if d.appliance_id == "helper"), None)
+        helper_dec = next(
+            (d for d in result.decisions if d.appliance_id == "helper"), None
+        )
         dep_dec = next((d for d in result.decisions if d.appliance_id == "dep"), None)
         assert dep_dec is not None and dep_dec.action == Action.OFF, (
             f"dep should be OFF (time window), got {dep_dec}"
         )
         assert helper_dec is not None
         assert helper_dec.action == Action.OFF
-        assert "helper-only" in helper_dec.reason.lower() or "no dependent" in helper_dec.reason.lower()
+        assert (
+            "helper-only" in helper_dec.reason.lower()
+            or "no dependent" in helper_dec.reason.lower()
+        )
 
     def test_helper_phase3_shed_protection(self):
         """Phase 3 SHED never sheds a dependency while its dependent is running.
         With helper_only set, that protection still applies — the helper is in
         _reverse_deps and Phase 3 honors the existing protection."""
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3513,12 +4038,18 @@ class TestHelperOnlyMode:
         """
         optimizer = _optimizer_for_tests()
         helper = _make_appliance(
-            id="helper", priority=500, helper_only=True,
-            nominal_power=200.0, on_threshold=0,
+            id="helper",
+            priority=500,
+            helper_only=True,
+            nominal_power=200.0,
+            on_threshold=0,
         )
         dependent = _make_appliance(
-            id="dep", priority=400, requires_appliance="helper",
-            nominal_power=1500.0, on_threshold=0,
+            id="dep",
+            priority=400,
+            requires_appliance="helper",
+            nominal_power=1500.0,
+            on_threshold=0,
         )
 
         # Excess = exactly 1700W (dep + helper) — just enough.
@@ -3554,18 +4085,24 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.IDLE, target_current=None,
-                reason="Insufficient excess (transient)", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.IDLE,
+                target_current=None,
+                reason="Insufficient excess (transient)",
+                overrides_plan=False,
             ),
         ]
         state_by_id = {"dep": _make_state(id="dep", is_on=True)}
-        assert optimizer._has_running_dependent("helper", decisions, state_by_id) is True
+        assert (
+            optimizer._has_running_dependent("helper", decisions, state_by_id) is True
+        )
 
     def test_has_running_dependent_idle_decision_state_off_returns_false(self):
         """IDLE decision with state.is_on=False → dep NOT running."""
@@ -3576,18 +4113,24 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.IDLE, target_current=None,
-                reason="Max daily activations reached", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.IDLE,
+                target_current=None,
+                reason="Max daily activations reached",
+                overrides_plan=False,
             ),
         ]
         state_by_id = {"dep": _make_state(id="dep", is_on=False)}
-        assert optimizer._has_running_dependent("helper", decisions, state_by_id) is False
+        assert (
+            optimizer._has_running_dependent("helper", decisions, state_by_id) is False
+        )
 
     def test_has_running_dependent_off_decision_is_authoritative(self):
         """OFF decision is authoritative even if state.is_on=True (HA lag)."""
@@ -3598,29 +4141,42 @@ class TestHelperOnlyMode:
             power_state=_make_power(excess=2500.0),
             appliances=[helper, dependent],
             appliance_states=[_make_state(id="helper"), _make_state(id="dep")],
-            plan=_empty_plan(), power_history=[_make_power(excess=2500.0)],
+            plan=_empty_plan(),
+            power_history=[_make_power(excess=2500.0)],
             tariff=_make_tariff(),
         )
 
         decisions = [
             ControlDecision(
-                appliance_id="dep", action=Action.OFF, target_current=None,
-                reason="Max daily runtime reached", overrides_plan=False,
+                appliance_id="dep",
+                action=Action.OFF,
+                target_current=None,
+                reason="Max daily runtime reached",
+                overrides_plan=False,
                 bypasses_cooldown=True,
             ),
         ]
         state_by_id = {"dep": _make_state(id="dep", is_on=True)}
-        assert optimizer._has_running_dependent("helper", decisions, state_by_id) is False
+        assert (
+            optimizer._has_running_dependent("helper", decisions, state_by_id) is False
+        )
 
     def test_helper_off_when_dependent_forced_off_by_safety_rule(self):
         """Dep safety rule forces OFF → helper mirrors OFF (OFF is authoritative)."""
         from datetime import time as dtime
         from dataclasses import replace
+
         optimizer = _optimizer_for_tests()
-        helper = _make_appliance(id="helper", priority=500, helper_only=True, nominal_power=200.0)
-        dependent = _make_appliance(id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0)
+        helper = _make_appliance(
+            id="helper", priority=500, helper_only=True, nominal_power=200.0
+        )
+        dependent = _make_appliance(
+            id="dep", priority=400, requires_appliance="helper", nominal_power=1500.0
+        )
         # Restrict dependent to a time window that excludes the test fixture time (12:00 UTC)
-        dependent = replace(dependent, start_after=dtime(22, 0), end_before=dtime(23, 0))
+        dependent = replace(
+            dependent, start_after=dtime(22, 0), end_before=dtime(23, 0)
+        )
 
         helper_state = _make_state(id="helper", is_on=True, current_power=200.0)
         dep_state = _make_state(id="dep", is_on=True, current_power=1500.0)
@@ -3680,9 +4236,14 @@ class TestDualBudgetInvariant:
         power = _make_power(excess=-300.0, pv=2700.0)
         history = [
             PowerState(
-                pv_production=4700.0, grid_export=2000.0, grid_import=0.0,
-                load_power=2700.0, excess_power=2000.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=4700.0,
+                grid_export=2000.0,
+                grid_import=0.0,
+                load_power=2700.0,
+                excess_power=2000.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * i),
             )
             for i in range(30)
@@ -3726,9 +4287,14 @@ class TestDualBudgetInvariant:
         power = _make_power(excess=1500.0, pv=5640.0)
         history = [
             PowerState(
-                pv_production=3640.0, grid_export=0.0, grid_import=500.0,
-                load_power=4140.0, excess_power=-500.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=3640.0,
+                grid_export=0.0,
+                grid_import=500.0,
+                load_power=4140.0,
+                excess_power=-500.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * i),
             )
             for i in range(30)
@@ -3784,9 +4350,14 @@ class TestDualBudgetInvariant:
         power = _make_power(excess=-300.0, pv=6600.0)
         history = [
             PowerState(
-                pv_production=8900.0, grid_export=2000.0, grid_import=0.0,
-                load_power=6900.0, excess_power=2000.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=8900.0,
+                grid_export=2000.0,
+                grid_import=0.0,
+                load_power=6900.0,
+                excess_power=2000.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * i),
             )
             for i in range(30)
@@ -3873,9 +4444,14 @@ class TestDualBudgetInvariant:
         power = _make_power(excess=1500.0, pv=9780.0)
         history = [
             PowerState(
-                pv_production=9080.0, grid_export=800.0, grid_import=0.0,
-                load_power=8280.0, excess_power=800.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=9080.0,
+                grid_export=800.0,
+                grid_import=0.0,
+                load_power=8280.0,
+                excess_power=800.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * i),
             )
             for i in range(30)
@@ -3943,6 +4519,7 @@ class TestDualBudgetInvariant:
         # _make_appliance doesn't expose averaging_window, so we use
         # dataclasses.replace to set it post-hoc.
         import dataclasses
+
         kona = dataclasses.replace(kona, averaging_window=900.0)
 
         state = _make_state(id="kona", is_on=True, current_power=4140.0)  # 6 A
@@ -3955,18 +4532,28 @@ class TestDualBudgetInvariant:
         # so Kona should see ~800 W as its avg_budget.
         recent_15 = [
             PowerState(
-                pv_production=4940.0, grid_export=800.0, grid_import=0.0,
-                load_power=4140.0, excess_power=800.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=4940.0,
+                grid_export=800.0,
+                grid_import=0.0,
+                load_power=4140.0,
+                excess_power=800.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * i),
             )
             for i in range(30)
         ]
         older_15 = [
             PowerState(
-                pv_production=4340.0, grid_export=200.0, grid_import=0.0,
-                load_power=4140.0, excess_power=200.0,
-                battery_soc=None, battery_power=None, ev_soc=None,
+                pv_production=4340.0,
+                grid_export=200.0,
+                grid_import=0.0,
+                load_power=4140.0,
+                excess_power=200.0,
+                battery_soc=None,
+                battery_power=None,
+                ev_soc=None,
                 timestamp=_utcnow() - timedelta(seconds=30 * (30 + i)),
             )
             for i in range(30)
@@ -3975,8 +4562,9 @@ class TestDualBudgetInvariant:
         # the coordinator appends to the history list.
         history = list(reversed(older_15)) + list(reversed(recent_15))
 
-        opt = _optimizer_for_tests(grid_voltage=230, off_threshold=-100,
-                                   min_good_samples=3)
+        opt = _optimizer_for_tests(
+            grid_voltage=230, off_threshold=-100, min_good_samples=3
+        )
         result = opt.optimize(
             power_state=power,
             appliances=[kona],
@@ -4163,21 +4751,28 @@ class TestKonaProdRegression2026_04_08:
 
     # (event_name, pv, load, current_excess, avg_excess, kona_drawn_power)
     _KONA_CASES = [
-        ("1116", 6019.0, 4537.0, 1482.0, 1325.0, 3430.0),   # 11:16:31
-        ("1159", 6585.0, 4759.0, 1826.0, 1364.0, 3654.0),   # 11:59:01
-        ("1257", 7019.0, 4051.0, 2968.0,  -29.0, 3565.0),   # 12:57:01 (worst case)
-        ("1320", 6911.0, 4024.0, 2887.0, 2094.0, 3524.0),   # 13:20:31
-        ("1342", 6861.0, 4293.0, 2568.0, 1856.0, 3141.0),   # 13:42:01
-        ("1422", 6529.0, 4258.0, 2271.0, 1694.0, 3089.0),   # 14:22:31
-        ("1439", 6436.0, 4398.0, 2038.0, 1738.0, 3471.0),   # 14:39:01
-        ("1516", 5827.0, 4484.0, 1343.0,  974.0, 3836.0),   # 15:16:31
-        ("1603", 5180.0, 3666.0, 1514.0, 1251.0, 3418.0),   # 16:03:01
+        ("1116", 6019.0, 4537.0, 1482.0, 1325.0, 3430.0),  # 11:16:31
+        ("1159", 6585.0, 4759.0, 1826.0, 1364.0, 3654.0),  # 11:59:01
+        ("1257", 7019.0, 4051.0, 2968.0, -29.0, 3565.0),  # 12:57:01 (worst case)
+        ("1320", 6911.0, 4024.0, 2887.0, 2094.0, 3524.0),  # 13:20:31
+        ("1342", 6861.0, 4293.0, 2568.0, 1856.0, 3141.0),  # 13:42:01
+        ("1422", 6529.0, 4258.0, 2271.0, 1694.0, 3089.0),  # 14:22:31
+        ("1439", 6436.0, 4398.0, 2038.0, 1738.0, 3471.0),  # 14:39:01
+        ("1516", 5827.0, 4484.0, 1343.0, 974.0, 3836.0),  # 15:16:31
+        ("1603", 5180.0, 3666.0, 1514.0, 1251.0, 3418.0),  # 16:03:01
     ]
 
-    @pytest.mark.parametrize("label,pv,load,cur,avg,drawn", _KONA_CASES,
-                             ids=[c[0] for c in _KONA_CASES])
+    @pytest.mark.parametrize(
+        "label,pv,load,cur,avg,drawn", _KONA_CASES, ids=[c[0] for c in _KONA_CASES]
+    )
     def test_no_shed_when_physical_excess_positive(
-        self, label, pv, load, cur, avg, drawn,
+        self,
+        label,
+        pv,
+        load,
+        cur,
+        avg,
+        drawn,
     ):
         """Kona stays ON (or SET_CURRENT) despite the mixed-unit bookkeeping
         artefacts that caused full-OFF on prod."""
@@ -4244,18 +4839,23 @@ class TestKonaProdRegression2026_04_08:
 # TestCheapWindowTargetAmps
 # ---------------------------------------------------------------------------
 
+
 class TestCheapWindowTargetAmps:
     """Unit tests for Optimizer._cheap_window_target_amps."""
 
     def test_returns_none_when_override_unset(self):
         optimizer = _optimizer_for_tests()
-        appliance = _make_appliance(cheap_grid_target_current=None, allow_grid_supplement=True)
+        appliance = _make_appliance(
+            cheap_grid_target_current=None, allow_grid_supplement=True
+        )
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
         assert optimizer._cheap_window_target_amps(appliance, tariff, phases=3) is None
 
     def test_returns_none_when_grid_supplement_disabled(self):
         optimizer = _optimizer_for_tests()
-        appliance = _make_appliance(cheap_grid_target_current=16.0, allow_grid_supplement=False)
+        appliance = _make_appliance(
+            cheap_grid_target_current=16.0, allow_grid_supplement=False
+        )
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
         assert optimizer._cheap_window_target_amps(appliance, tariff, phases=3) is None
 
@@ -4319,6 +4919,7 @@ class TestCheapWindowTargetAmps:
 # TestCheapGridTargetSite1
 # ---------------------------------------------------------------------------
 
+
 class TestCheapGridTargetSite1:
     """Tests for the grid-supplement entry point in _allocate_dynamic_current (Site 1).
 
@@ -4331,16 +4932,25 @@ class TestCheapGridTargetSite1:
         """OFF appliance, cheap, low excess, override=max_current → SET_CURRENT max_current."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         decision, power_consumed = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=0.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=0.0,
+            tariff=tariff,
+            plan=None,
         )
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 16.0
@@ -4350,34 +4960,55 @@ class TestCheapGridTargetSite1:
     def test_dynamic_current_cheap_grid_target_capped_by_max_grid_power(self):
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
-            max_grid_power=4000.0, cheap_grid_target_current=16.0,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
+            max_grid_power=4000.0,
+            cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=0.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=0.0,
+            tariff=tariff,
+            plan=None,
         )
         # 4000W / (230*3) = 5.797A → floored 5.7
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 5.7
 
-    def test_dynamic_current_cheap_grid_target_none_preserves_min_current_behavior(self):
+    def test_dynamic_current_cheap_grid_target_none_preserves_min_current_behavior(
+        self,
+    ):
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=None,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=0.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=0.0,
+            tariff=tariff,
+            plan=None,
         )
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 6.0  # min_current, the existing behaviour
@@ -4385,16 +5016,25 @@ class TestCheapGridTargetSite1:
     def test_dynamic_current_override_requires_grid_supplement(self):
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
             allow_grid_supplement=False,  # disabled
-            cheap_price_threshold=0.05, cheap_grid_target_current=16.0,
+            cheap_price_threshold=0.05,
+            cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=0.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=0.0,
+            tariff=tariff,
+            plan=None,
         )
         # Override is gated by allow_grid_supplement → existing IDLE branch fires
         assert decision.action == Action.IDLE
@@ -4403,6 +5043,7 @@ class TestCheapGridTargetSite1:
 # ---------------------------------------------------------------------------
 # TestCheapGridTargetSite2
 # ---------------------------------------------------------------------------
+
 
 class TestCheapGridTargetSite2:
     """Tests for the natural-scaling path in _allocate_dynamic_current (Site 2).
@@ -4416,9 +5057,14 @@ class TestCheapGridTargetSite2:
         """OFF appliance starting on partial solar + cheap tariff → uses override even though excess alone supports a lower current."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
@@ -4427,7 +5073,11 @@ class TestCheapGridTargetSite2:
         # Excess supports natural amps of 5520/(230*3) = 8A — without override, decision would be 8A.
         # Need avg_budget >= min_watts_needed (6 * 230 * 3 = 4140 + on_threshold) to enter natural-scaling path.
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=5520.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=5520.0,
+            tariff=tariff,
+            plan=None,
         )
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 16.0  # override clamped up
@@ -4436,16 +5086,25 @@ class TestCheapGridTargetSite2:
         """OFF appliance, NOT cheap, override set → existing solar-driven behaviour."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.10, cheap_threshold=0.05)  # not cheap
 
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=5520.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=5520.0,
+            tariff=tariff,
+            plan=None,
         )
         # 5520/(230*3) = 8.0A naturally
         assert decision.action == Action.SET_CURRENT
@@ -4462,17 +5121,27 @@ class TestCheapGridTargetSite2:
         override — the override only ever clamps UP."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
-            max_grid_power=4000.0, cheap_grid_target_current=16.0,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
+            max_grid_power=4000.0,
+            cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=False)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         # avg_budget large enough to naturally support max_current
         decision, _ = optimizer._allocate_dynamic_current(
-            appliance, state, avg_budget=15_000.0, tariff=tariff, plan=None,
+            appliance,
+            state,
+            avg_budget=15_000.0,
+            tariff=tariff,
+            plan=None,
         )
         # Natural is 16A (clamped to max_current). Override capped to 5.7 by
         # max_grid_power. Site 2 only clamps UP (strict greater), so 16 stays.
@@ -4483,6 +5152,7 @@ class TestCheapGridTargetSite2:
 # ---------------------------------------------------------------------------
 # TestCheapGridTargetSite3
 # ---------------------------------------------------------------------------
+
 
 class TestCheapGridTargetSite3:
     """Tests for the already-ON dynamic-current branch in _allocate_appliance (Site 3).
@@ -4495,9 +5165,14 @@ class TestCheapGridTargetSite3:
         """ON appliance, cheap, low solar → stays at override target (grid supplements)."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         # Currently drawing min_current (4140W = 6A * 230V * 3 phases)
@@ -4508,8 +5183,12 @@ class TestCheapGridTargetSite3:
         # (current_power=4140W + budget 0 = 4140W → 4140/(230*3)=6.0A clamped to min_current).
         # With override=16A, Site 3 should clamp UP to 16A.
         decision, _ = optimizer._allocate_appliance(
-            appliance, state, avg_budget=0.0, instant_budget=0.0,
-            plan=None, tariff=tariff,
+            appliance,
+            state,
+            avg_budget=0.0,
+            instant_budget=0.0,
+            plan=None,
+            tariff=tariff,
         )
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 16.0
@@ -4518,17 +5197,26 @@ class TestCheapGridTargetSite3:
         """ON appliance, NOT cheap → existing solar-driven scaling preserved."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=True, current_power=4140.0)
         tariff = _make_tariff(current_price=0.10, cheap_threshold=0.05)  # NOT cheap
 
         decision, _ = optimizer._allocate_appliance(
-            appliance, state, avg_budget=0.0, instant_budget=0.0,
-            plan=None, tariff=tariff,
+            appliance,
+            state,
+            avg_budget=0.0,
+            instant_budget=0.0,
+            plan=None,
+            tariff=tariff,
         )
         # Without override, current_power 4140 + 0 budget → 4140/(230*3)=6.0A, clamped to min_current
         assert decision.action == Action.SET_CURRENT
@@ -4541,17 +5229,27 @@ class TestCheapGridTargetSite3:
         Strict-greater clamp does NOT modify, so target stays at 6A."""
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
-            max_grid_power=4000.0, cheap_grid_target_current=16.0,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
+            max_grid_power=4000.0,
+            cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=True, current_power=4140.0)
         tariff = _make_tariff(current_price=0.01, cheap_threshold=0.05)
 
         decision, _ = optimizer._allocate_appliance(
-            appliance, state, avg_budget=0.0, instant_budget=0.0,
-            plan=None, tariff=tariff,
+            appliance,
+            state,
+            avg_budget=0.0,
+            instant_budget=0.0,
+            plan=None,
+            tariff=tariff,
         )
         # 4000/(230*3) = 5.797 → floored 5.7A. min_current=6.0 clamps natural up → 6.0
         # Override 5.7 < natural 6.0, strict-greater fails, target stays at 6.0
@@ -4570,17 +5268,26 @@ class TestCheapGridTargetSite3:
         """
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         state = _make_state(appliance.id, is_on=True, current_power=2978.0)
         tariff = _make_tariff(current_price=-0.086, cheap_threshold=0.05)
 
         decision, power_delta = optimizer._allocate_appliance(
-            appliance, state, avg_budget=4410.0, instant_budget=4410.0,
-            plan=None, tariff=tariff,
+            appliance,
+            state,
+            avg_budget=4410.0,
+            instant_budget=4410.0,
+            plan=None,
+            tariff=tariff,
         )
         assert decision.action == Action.SET_CURRENT
         assert decision.target_current == 16.0
@@ -4618,9 +5325,14 @@ class TestCheapGridTargetSite3:
         """
         optimizer = _optimizer_for_tests(grid_voltage=230)
         appliance = _make_appliance(
-            dynamic_current=True, current_entity="number.kona_curr",
-            min_current=6.0, max_current=16.0, phases=3, current_step=0.1,
-            allow_grid_supplement=True, cheap_price_threshold=0.05,
+            dynamic_current=True,
+            current_entity="number.kona_curr",
+            min_current=6.0,
+            max_current=16.0,
+            phases=3,
+            current_step=0.1,
+            allow_grid_supplement=True,
+            cheap_price_threshold=0.05,
             cheap_grid_target_current=16.0,
         )
         # Kona running at full power; excess_for_adjustment dropped below
@@ -4630,8 +5342,12 @@ class TestCheapGridTargetSite3:
         tariff = _make_tariff(current_price=-0.137, cheap_threshold=0.05)
 
         decision, _ = optimizer._allocate_appliance(
-            appliance, state, avg_budget=-7500.0, instant_budget=-7500.0,
-            plan=None, tariff=tariff,
+            appliance,
+            state,
+            avg_budget=-7500.0,
+            instant_budget=-7500.0,
+            plan=None,
+            tariff=tariff,
         )
         assert decision.action == Action.SET_CURRENT, (
             f"override must skip the early return; got action={decision.action} "
@@ -4658,8 +5374,11 @@ class TestPhase4CheapTariffDischargeBlock:
     @staticmethod
     def _decision(appliance_id: str, action: Action, reason: str):
         return ControlDecision(
-            appliance_id=appliance_id, action=action,
-            target_current=None, reason=reason, overrides_plan=False,
+            appliance_id=appliance_id,
+            action=action,
+            target_current=None,
+            reason=reason,
+            overrides_plan=False,
         )
 
     def test_cheap_window_override_decision_blocks_discharge(self):
@@ -4667,13 +5386,17 @@ class TestPhase4CheapTariffDischargeBlock:
         triggers the discharge block."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(id="kona")
-        decisions = [self._decision(
-            "kona", Action.SET_CURRENT,
-            "Grid supplement (cheap-window target): 16.0A (11040W, 4909W solar-supportable)",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.SET_CURRENT,
+                "Grid supplement (cheap-window target): 16.0A (11040W, 4909W solar-supportable)",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
         )
 
         assert action.should_limit is True
@@ -4684,13 +5407,17 @@ class TestPhase4CheapTariffDischargeBlock:
         also triggers the block (same substring, different code path)."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(id="kona")
-        decisions = [self._decision(
-            "kona", Action.SET_CURRENT,
-            "Grid supplement (export solar at 0.080, buy grid at -0.137): 16.0A",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.SET_CURRENT,
+                "Grid supplement (export solar at 0.080, buy grid at -0.137): 16.0A",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
         )
 
         assert action.should_limit is True
@@ -4707,13 +5434,17 @@ class TestPhase4CheapTariffDischargeBlock:
             is_big_consumer=True,
             battery_max_discharge_override=2000.0,
         )
-        decisions = [self._decision(
-            "kona", Action.SET_CURRENT,
-            "Grid supplement (cheap-window target): 16.0A (...)",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.SET_CURRENT,
+                "Grid supplement (cheap-window target): 16.0A (...)",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
         )
 
         assert action.max_discharge_watts == 0, (
@@ -4726,12 +5457,18 @@ class TestPhase4CheapTariffDischargeBlock:
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(id="kona")
         # SHED would have shed Kona under force_charge; simulate by using OFF.
-        decisions = [self._decision(
-            "kona", Action.OFF, "Shed: insufficient excess (priority 1)",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.OFF,
+                "Shed: insufficient excess (priority 1)",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance], force_charge=True,
+            decisions,
+            [appliance],
+            force_charge=True,
         )
 
         assert action.should_limit is True
@@ -4743,7 +5480,9 @@ class TestPhase4CheapTariffDischargeBlock:
         decisions = []  # no appliances at all
 
         action = optimizer._battery_discharge_protection(
-            decisions, [], auto_grid_charge_engaged=True,
+            decisions,
+            [],
+            auto_grid_charge_engaged=True,
         )
 
         assert action.should_limit is True
@@ -4754,12 +5493,17 @@ class TestPhase4CheapTariffDischargeBlock:
         no cheap-tariff block; existing big-consumer / no-limit paths apply."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(id="washer", is_big_consumer=False)
-        decisions = [self._decision(
-            "washer", Action.ON, "Excess available (1000W >= 500W needed)",
-        )]
+        decisions = [
+            self._decision(
+                "washer",
+                Action.ON,
+                "Excess available (1000W >= 500W needed)",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
         )
 
         # No big consumer, no triggers → no limit
@@ -4770,14 +5514,18 @@ class TestPhase4CheapTariffDischargeBlock:
         unlike SoC-protection, no Action.OFF is inserted."""
         optimizer = _optimizer_for_tests()
         appliance = _make_appliance(id="kona")
-        decisions = [self._decision(
-            "kona", Action.SET_CURRENT,
-            "Grid supplement (cheap-window target): 16.0A (...)",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.SET_CURRENT,
+                "Grid supplement (cheap-window target): 16.0A (...)",
+            )
+        ]
         decisions_before = list(decisions)  # snapshot
 
         optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
         )
 
         # Phase 4 should NOT have replaced any decision with Action.OFF.
@@ -4794,13 +5542,17 @@ class TestPhase4CheapTariffDischargeBlock:
             is_big_consumer=False,  # standard appliance, eligible for shed
             on_only=False,
         )
-        decisions = [self._decision(
-            "kona", Action.SET_CURRENT,
-            "Grid supplement (cheap-window target): 16.0A (...)",
-        )]
+        decisions = [
+            self._decision(
+                "kona",
+                Action.SET_CURRENT,
+                "Grid supplement (cheap-window target): 16.0A (...)",
+            )
+        ]
 
         action = optimizer._battery_discharge_protection(
-            decisions, [appliance],
+            decisions,
+            [appliance],
             battery_soc=5.0,
             min_battery_soc=10.0,
             force_charge=True,  # cheap-tariff trigger ALSO active
@@ -4811,4 +5563,3 @@ class TestPhase4CheapTariffDischargeBlock:
         # SoC-protection sheds → decision was replaced with Action.OFF.
         assert decisions[0].action == Action.OFF
         assert "Battery SoC protection" in decisions[0].reason
-

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -609,7 +609,7 @@ class TestOptimizerBudgets:
         # 500 W excess remains available to the pool pump.
         assert decisions["pool_pump"].action == Action.ON
         assert "500W >= 300W" in decisions["pool_pump"].reason
-    
+
     def test_avg_budget_tracked(self):
         """Two appliances: first takes budget, second gets none."""
         optimizer = _optimizer_for_tests()

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -555,6 +555,61 @@ class TestOptimizerDynamicCurrent:
 class TestOptimizerBudgets:
     """Test that the avg_budget is tracked correctly across allocations."""
 
+    def test_disconnected_dynamic_override_does_not_consume_budget(self):
+        """A disconnected EV in manual override must not block later appliances."""
+        optimizer = _optimizer_for_tests()
+
+        wallbox = _make_appliance(
+            id="wallbox",
+            name="Wallbox",
+            priority=1,
+            nominal_power=3680.0,
+            dynamic_current=True,
+            min_current=6.0,
+            max_current=16.0,
+            current_entity="number.wallbox_current",
+            ev_connected_entity="binary_sensor.ev_connected",
+            phases=1,
+            override_active=True,
+        )
+        pool_pump = _make_appliance(
+            id="pool_pump",
+            name="Poolpumpe",
+            priority=2,
+            nominal_power=100.0,
+        )
+
+        wallbox_state = _make_state(
+            id="wallbox",
+            is_on=False,
+            current_power=0.0,
+            ev_connected=False,
+        )
+        pool_pump_state = _make_state(id="pool_pump")
+
+        power = _make_power(excess=500.0)
+
+        result = optimizer.optimize(
+            power_state=power,
+            appliances=[wallbox, pool_pump],
+            appliance_states=[wallbox_state, pool_pump_state],
+            plan=_empty_plan(),
+            power_history=[power],
+            tariff=_make_tariff(),
+        )
+
+        decisions = {d.appliance_id: d for d in result.decisions}
+
+        # Manual override is still active and prepares the wallbox for 16 A.
+        assert decisions["wallbox"].action == Action.SET_CURRENT
+        assert decisions["wallbox"].target_current == 16.0
+        assert decisions["wallbox"].overrides_plan is True
+
+        # But the disconnected wallbox must not reserve 3680 W, so the
+        # 500 W excess remains available to the pool pump.
+        assert decisions["pool_pump"].action == Action.ON
+        assert "500W >= 300W" in decisions["pool_pump"].reason
+    
     def test_avg_budget_tracked(self):
         """Two appliances: first takes budget, second gets none."""
         optimizer = _optimizer_for_tests()

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -7,6 +7,7 @@ Tests verify that:
 - Validation logic works identically to the main config flow
 - Completing the flow creates an options entry
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -39,7 +40,6 @@ from custom_components.pv_excess_control.const import (
     CONF_PV_POWER,
     CONF_TARIFF_PROVIDER,
     DEFAULT_CONTROLLER_INTERVAL,
-    DEFAULT_GRID_VOLTAGE,
     DEFAULT_PLANNER_INTERVAL,
     DOMAIN,
     BatteryStrategy,
@@ -74,7 +74,9 @@ def _make_config_entry(data: dict[str, Any] | None = None) -> MagicMock:
     return entry
 
 
-def _make_options_flow(entry_data: dict[str, Any] | None = None) -> PvExcessControlOptionsFlow:
+def _make_options_flow(
+    entry_data: dict[str, Any] | None = None,
+) -> PvExcessControlOptionsFlow:
     """Create a PvExcessControlOptionsFlow with a mocked config entry."""
     config_entry = _make_config_entry(entry_data)
     flow = PvExcessControlOptionsFlow()
@@ -138,6 +140,7 @@ class TestOptionsFlowExists:
     def test_options_flow_is_options_flow_subclass(self):
         """PvExcessControlOptionsFlow inherits from OptionsFlow."""
         from homeassistant import config_entries
+
         assert issubclass(PvExcessControlOptionsFlow, config_entries.OptionsFlow)
 
 
@@ -288,9 +291,7 @@ class TestOptionsStepSensors:
         flow = _make_options_flow()
         flow.data[CONF_INVERTER_TYPE] = InverterType.STANDARD
 
-        result = await flow.async_step_sensors(
-            user_input={CONF_PV_POWER: "sensor.pv"}
-        )
+        result = await flow.async_step_sensors(user_input={CONF_PV_POWER: "sensor.pv"})
 
         assert result["type"] == "form"
         assert result["step_id"] == "sensors"
@@ -582,12 +583,14 @@ class TestOptionsStepSettings:
         """Settings step with valid input creates an options entry."""
         flow = _make_options_flow()
         # Populate flow.data with required fields
-        flow.data.update({
-            CONF_INVERTER_TYPE: InverterType.HYBRID,
-            CONF_GRID_VOLTAGE: 230,
-            CONF_PV_POWER: "sensor.pv",
-            CONF_GRID_EXPORT: "sensor.grid_export",
-        })
+        flow.data.update(
+            {
+                CONF_INVERTER_TYPE: InverterType.HYBRID,
+                CONF_GRID_VOLTAGE: 230,
+                CONF_PV_POWER: "sensor.pv",
+                CONF_GRID_EXPORT: "sensor.grid_export",
+            }
+        )
 
         result = await flow.async_step_settings(
             user_input={

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,12 +1,12 @@
 """Tests for PV Excess Control planner - timeline, battery, scheduling & plan."""
+
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta, UTC
 
 import pytest
 
 from custom_components.pv_excess_control.models import (
-    Action,
     ApplianceConfig,
     BatteryAllocation,
     BatteryConfig,
@@ -15,7 +15,6 @@ from custom_components.pv_excess_control.models import (
     ForecastData,
     HourlyForecast,
     Plan,
-    PlanEntry,
     PlanReason,
     TariffInfo,
     TariffWindow,
@@ -28,9 +27,10 @@ from custom_components.pv_excess_control.planner import Planner
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _dt(hour: int, minute: int = 0) -> datetime:
     """Create a UTC datetime on 2026-03-22 at the given hour:minute."""
-    return datetime(2026, 3, 22, hour, minute, 0, tzinfo=timezone.utc)
+    return datetime(2026, 3, 22, hour, minute, 0, tzinfo=UTC)
 
 
 def _make_hourly_forecast(
@@ -93,6 +93,7 @@ def _make_battery_config(
 # ===========================================================================
 # TestBuildTimeline
 # ===========================================================================
+
 
 class TestBuildTimeline:
     """Tests for Planner.build_timeline()."""
@@ -232,7 +233,7 @@ class TestBuildTimeline:
         forecast = ForecastData(
             remaining_today_kwh=1.0,
             hourly_breakdown=[
-                _make_hourly_forecast(10, 300),   # Below base load
+                _make_hourly_forecast(10, 300),  # Below base load
                 _make_hourly_forecast(11, 1500),  # Above base load
             ],
         )
@@ -324,6 +325,7 @@ class TestBuildTimeline:
 # TestBatteryStrategy
 # ===========================================================================
 
+
 class TestBatteryStrategy:
     """Tests for Planner.calculate_battery_strategy()."""
 
@@ -333,14 +335,20 @@ class TestBatteryStrategy:
         # Timeline: 2 hours, each with 1000W excess -> 2kWh total
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.20,
+                is_cheap=False,
             ),
             TimeSlot(
-                start=_dt(11), end=_dt(12),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.25, is_cheap=False,
+                start=_dt(11),
+                end=_dt(12),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.25,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -364,14 +372,20 @@ class TestBatteryStrategy:
         """APPLIANCE_FIRST charges from whatever excess remains."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.20,
+                is_cheap=False,
             ),
             TimeSlot(
-                start=_dt(11), end=_dt(12),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.25, is_cheap=False,
+                start=_dt(11),
+                end=_dt(12),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.25,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -394,14 +408,20 @@ class TestBatteryStrategy:
         """BALANCED splits excess proportionally (50/50)."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.20,
+                is_cheap=False,
             ),
             TimeSlot(
-                start=_dt(11), end=_dt(12),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.25, is_cheap=False,
+                start=_dt(11),
+                end=_dt(12),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.25,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -426,9 +446,12 @@ class TestBatteryStrategy:
         """If current SoC >= target, no charging needed."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.20,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -449,14 +472,20 @@ class TestBatteryStrategy:
         """Factor in cheap tariff windows for grid charging."""
         slots = [
             TimeSlot(
-                start=_dt(2), end=_dt(3),
-                expected_solar_watts=0, expected_excess_watts=0,
-                price=0.05, is_cheap=True,  # Cheap nighttime slot
+                start=_dt(2),
+                end=_dt(3),
+                expected_solar_watts=0,
+                expected_excess_watts=0,
+                price=0.05,
+                is_cheap=True,  # Cheap nighttime slot
             ),
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.25, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.25,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -481,14 +510,20 @@ class TestBatteryStrategy:
         """When allow_grid_charging=False, cheap windows are not used for battery."""
         slots = [
             TimeSlot(
-                start=_dt(2), end=_dt(3),
-                expected_solar_watts=0, expected_excess_watts=0,
-                price=0.05, is_cheap=True,
+                start=_dt(2),
+                end=_dt(3),
+                expected_solar_watts=0,
+                expected_excess_watts=0,
+                price=0.05,
+                is_cheap=True,
             ),
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.25, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.25,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -510,9 +545,12 @@ class TestBatteryStrategy:
         """When charging need exceeds total available excess, reserve everything."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=600, expected_excess_watts=100,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=600,
+                expected_excess_watts=100,
+                price=0.20,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -534,13 +572,17 @@ class TestBatteryStrategy:
         """At 100% SoC, no charging needed regardless of target."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.20, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.20,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
-            capacity_kwh=10.0, target_soc=100.0,
+            capacity_kwh=10.0,
+            target_soc=100.0,
             strategy=BatteryStrategy.BATTERY_FIRST,
         )
 
@@ -564,14 +606,20 @@ class TestBatteryStrategy:
         """BATTERY_FIRST should prefer cheaper slots for charging."""
         slots = [
             TimeSlot(
-                start=_dt(10), end=_dt(11),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.30, is_cheap=False,
+                start=_dt(10),
+                end=_dt(11),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.30,
+                is_cheap=False,
             ),
             TimeSlot(
-                start=_dt(11), end=_dt(12),
-                expected_solar_watts=1500, expected_excess_watts=1000,
-                price=0.10, is_cheap=False,
+                start=_dt(11),
+                end=_dt(12),
+                expected_solar_watts=1500,
+                expected_excess_watts=1000,
+                price=0.10,
+                is_cheap=False,
             ),
         ]
         config = _make_battery_config(
@@ -596,6 +644,7 @@ class TestBatteryStrategy:
 # ---------------------------------------------------------------------------
 # Appliance helper
 # ---------------------------------------------------------------------------
+
 
 def _make_appliance(
     appliance_id: str = "app1",
@@ -654,7 +703,9 @@ def _make_tariff_info(
         current_price=current_price,
         feed_in_tariff=feed_in_tariff,
         cheap_price_threshold=cheap_threshold,
-        battery_charge_price_threshold=battery_charge_threshold if battery_charge_threshold is not None else cheap_threshold,
+        battery_charge_price_threshold=battery_charge_threshold
+        if battery_charge_threshold is not None
+        else cheap_threshold,
         windows=windows or [],
     )
 
@@ -662,6 +713,7 @@ def _make_tariff_info(
 # ===========================================================================
 # TestApplianceScheduling
 # ===========================================================================
+
 
 class TestApplianceScheduling:
     """Tests for appliance scheduling logic."""
@@ -676,8 +728,8 @@ class TestApplianceScheduling:
             hourly_breakdown=[
                 _make_hourly_forecast(10, 1500),  # 1000W excess after 500W base
                 _make_hourly_forecast(11, 1500),  # 1000W excess after 500W base
-                _make_hourly_forecast(12, 500),   # 0W excess
-                _make_hourly_forecast(13, 500),   # 0W excess
+                _make_hourly_forecast(12, 500),  # 0W excess
+                _make_hourly_forecast(13, 500),  # 0W excess
             ],
         )
         tariffs = [
@@ -719,7 +771,9 @@ class TestApplianceScheduling:
 
         assert len(high_entries) >= 1
         # High priority should get excess slots
-        excess_reasons = [e for e in high_entries if e.reason == PlanReason.EXCESS_AVAILABLE]
+        excess_reasons = [
+            e for e in high_entries if e.reason == PlanReason.EXCESS_AVAILABLE
+        ]
         assert len(excess_reasons) >= 1
 
         # Low priority should NOT get excess slots (taken by high prio)
@@ -879,6 +933,7 @@ class TestApplianceScheduling:
 # TestExportLimitManagement
 # ===========================================================================
 
+
 class TestExportLimitManagement:
     """Tests for export limit management."""
 
@@ -938,6 +993,7 @@ class TestExportLimitManagement:
 # TestWeatherPreplanning
 # ===========================================================================
 
+
 class TestWeatherPreplanning:
     """Tests for weather pre-planning."""
 
@@ -985,7 +1041,9 @@ class TestWeatherPreplanning:
         entries = [e for e in plan.entries if e.appliance_id == "pool_pump"]
         # With poor tomorrow, the planner should schedule additional entries
         # beyond the minimum 2 hours
-        weather_entries = [e for e in entries if e.reason == PlanReason.WEATHER_PREPLANNING]
+        weather_entries = [
+            e for e in entries if e.reason == PlanReason.WEATHER_PREPLANNING
+        ]
         # The plan should contain weather pre-planning entries
         assert len(weather_entries) >= 1
 
@@ -993,6 +1051,7 @@ class TestWeatherPreplanning:
 # ===========================================================================
 # TestCreatePlan
 # ===========================================================================
+
 
 class TestCreatePlan:
     """Tests for the full create_plan() method."""
@@ -1123,6 +1182,7 @@ class TestCreatePlan:
 # TestBatteryChargeThreshold
 # ===========================================================================
 
+
 class TestBatteryChargeThreshold:
     """Test that battery grid charging uses battery_charge_price_threshold, not cheap_price_threshold."""
 
@@ -1132,9 +1192,12 @@ class TestBatteryChargeThreshold:
         # Slot price is 0.04 (below battery threshold) -> should charge
         slots = [
             TimeSlot(
-                start=_dt(2), end=_dt(3),
-                expected_solar_watts=0.0, expected_excess_watts=0.0,
-                price=0.04, is_cheap=True,
+                start=_dt(2),
+                end=_dt(3),
+                expected_solar_watts=0.0,
+                expected_excess_watts=0.0,
+                price=0.04,
+                is_cheap=True,
             ),
         ]
         battery_config = _make_battery_config(
@@ -1150,7 +1213,10 @@ class TestBatteryChargeThreshold:
 
         planner = Planner()
         alloc = planner.calculate_battery_strategy(
-            slots, battery_config, current_soc=50.0, tariff=tariff,
+            slots,
+            battery_config,
+            current_soc=50.0,
+            tariff=tariff,
         )
 
         # Should have reserved the slot for grid charging
@@ -1163,9 +1229,12 @@ class TestBatteryChargeThreshold:
         # Slot price is 0.08 (above battery threshold but below cheap threshold)
         slots = [
             TimeSlot(
-                start=_dt(2), end=_dt(3),
-                expected_solar_watts=0.0, expected_excess_watts=0.0,
-                price=0.08, is_cheap=True,  # is_cheap=True from global!
+                start=_dt(2),
+                end=_dt(3),
+                expected_solar_watts=0.0,
+                expected_excess_watts=0.0,
+                price=0.08,
+                is_cheap=True,  # is_cheap=True from global!
             ),
         ]
         battery_config = _make_battery_config(
@@ -1181,7 +1250,10 @@ class TestBatteryChargeThreshold:
 
         planner = Planner()
         alloc = planner.calculate_battery_strategy(
-            slots, battery_config, current_soc=50.0, tariff=tariff,
+            slots,
+            battery_config,
+            current_soc=50.0,
+            tariff=tariff,
         )
 
         # Should NOT have reserved (price above battery threshold)
@@ -1192,6 +1264,7 @@ class TestBatteryChargeThreshold:
 # TestPlannerPerApplianceThreshold
 # ===========================================================================
 
+
 class TestPlannerPerApplianceThreshold:
     """Test that planner Tier 2 scheduling uses per-appliance cheap threshold."""
 
@@ -1201,9 +1274,12 @@ class TestPlannerPerApplianceThreshold:
         # Slot at price 0.10: is_cheap=False (global), but below per-appliance threshold
         slots = [
             TimeSlot(
-                start=_dt(1), end=_dt(2),
-                expected_solar_watts=0.0, expected_excess_watts=0.0,
-                price=0.10, is_cheap=False,
+                start=_dt(1),
+                end=_dt(2),
+                expected_solar_watts=0.0,
+                expected_excess_watts=0.0,
+                price=0.10,
+                is_cheap=False,
             ),
         ]
         appliance = _make_appliance(
@@ -1223,7 +1299,10 @@ class TestPlannerPerApplianceThreshold:
 
         planner = Planner()
         entries = planner.schedule_appliances(
-            slots, battery_alloc, [appliance], cheap_price_threshold=0.05,
+            slots,
+            battery_alloc,
+            [appliance],
+            cheap_price_threshold=0.05,
         )
 
         # Should schedule in the slot via Tier 2 (per-appliance threshold allows it)
@@ -1236,9 +1315,12 @@ class TestPlannerPerApplianceThreshold:
         # Global threshold=0.05, slot price=0.10 (above global)
         slots = [
             TimeSlot(
-                start=_dt(1), end=_dt(2),
-                expected_solar_watts=0.0, expected_excess_watts=0.0,
-                price=0.10, is_cheap=False,
+                start=_dt(1),
+                end=_dt(2),
+                expected_solar_watts=0.0,
+                expected_excess_watts=0.0,
+                price=0.10,
+                is_cheap=False,
             ),
         ]
         appliance = _make_appliance(
@@ -1258,7 +1340,10 @@ class TestPlannerPerApplianceThreshold:
 
         planner = Planner()
         entries = planner.schedule_appliances(
-            slots, battery_alloc, [appliance], cheap_price_threshold=0.05,
+            slots,
+            battery_alloc,
+            [appliance],
+            cheap_price_threshold=0.05,
         )
 
         # Tier 2 should NOT schedule (price above global threshold, no per-appliance override)

--- a/tests/test_runtime_counting.py
+++ b/tests/test_runtime_counting.py
@@ -1,4 +1,5 @@
 """Tests for runtime counting with completion_power_threshold."""
+
 from datetime import timedelta
 
 import pytest
@@ -12,17 +13,29 @@ class TestRuntimeCounting:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         config = ApplianceConfig(
-            id="heater", name="Heater", entity_id="switch.heater",
-            priority=1, phases=1, nominal_power=6000.0,
+            id="heater",
+            name="Heater",
+            entity_id="switch.heater",
+            priority=1,
+            phases=1,
+            nominal_power=6000.0,
             actual_power_entity="sensor.heater_power",
-            dynamic_current=False, current_entity=None,
-            min_current=0.0, max_current=0.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=timedelta(hours=3),
-            max_daily_runtime=None, schedule_deadline=None,
-            switch_interval=300, allow_grid_supplement=False,
-            max_grid_power=None, completion_power_threshold=500.0,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=0.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=timedelta(hours=3),
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
+            max_grid_power=None,
+            completion_power_threshold=500.0,
         )
 
         # Simulate runtime counting logic from coordinator
@@ -47,17 +60,29 @@ class TestRuntimeCounting:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         config = ApplianceConfig(
-            id="heater", name="Heater", entity_id="switch.heater",
-            priority=1, phases=1, nominal_power=6000.0,
+            id="heater",
+            name="Heater",
+            entity_id="switch.heater",
+            priority=1,
+            phases=1,
+            nominal_power=6000.0,
             actual_power_entity="sensor.heater_power",
-            dynamic_current=False, current_entity=None,
-            min_current=0.0, max_current=0.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=timedelta(hours=3),
-            max_daily_runtime=None, schedule_deadline=None,
-            switch_interval=300, allow_grid_supplement=False,
-            max_grid_power=None, completion_power_threshold=500.0,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=0.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=timedelta(hours=3),
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
+            max_grid_power=None,
+            completion_power_threshold=500.0,
         )
 
         is_on = True
@@ -80,16 +105,27 @@ class TestRuntimeCounting:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         config = ApplianceConfig(
-            id="heater", name="Heater", entity_id="switch.heater",
-            priority=1, phases=1, nominal_power=6000.0,
+            id="heater",
+            name="Heater",
+            entity_id="switch.heater",
+            priority=1,
+            phases=1,
+            nominal_power=6000.0,
             actual_power_entity="sensor.heater_power",
-            dynamic_current=False, current_entity=None,
-            min_current=0.0, max_current=0.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=timedelta(hours=3),
-            max_daily_runtime=None, schedule_deadline=None,
-            switch_interval=300, allow_grid_supplement=False,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=0.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=timedelta(hours=3),
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
             max_grid_power=None,
             # completion_power_threshold defaults to None
         )
@@ -115,16 +151,27 @@ class TestRuntimeCounting:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         config = ApplianceConfig(
-            id="heater", name="Heater", entity_id="switch.heater",
-            priority=1, phases=1, nominal_power=6000.0,
+            id="heater",
+            name="Heater",
+            entity_id="switch.heater",
+            priority=1,
+            phases=1,
+            nominal_power=6000.0,
             actual_power_entity="sensor.heater_power",
-            dynamic_current=False, current_entity=None,
-            min_current=0.0, max_current=0.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=None,
-            max_daily_runtime=None, schedule_deadline=None,
-            switch_interval=300, allow_grid_supplement=False,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=0.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
             max_grid_power=None,
         )
 
@@ -133,7 +180,8 @@ class TestRuntimeCounting:
 
         # New logic: only fall back to nominal when no actual_power_entity
         power_for_energy = (
-            current_power if current_power > 0
+            current_power
+            if current_power > 0
             else (0.0 if config.actual_power_entity else config.nominal_power)
         )
         energy_delta = (power_for_energy * cycle_seconds) / 3600 / 1000
@@ -145,16 +193,27 @@ class TestRuntimeCounting:
         from custom_components.pv_excess_control.models import ApplianceConfig
 
         config = ApplianceConfig(
-            id="heater", name="Heater", entity_id="switch.heater",
-            priority=1, phases=1, nominal_power=6000.0,
+            id="heater",
+            name="Heater",
+            entity_id="switch.heater",
+            priority=1,
+            phases=1,
+            nominal_power=6000.0,
             actual_power_entity=None,  # No power sensor
-            dynamic_current=False, current_entity=None,
-            min_current=0.0, max_current=0.0,
-            ev_soc_entity=None, ev_connected_entity=None,
-            is_big_consumer=False, battery_max_discharge_override=None,
-            on_only=False, min_daily_runtime=None,
-            max_daily_runtime=None, schedule_deadline=None,
-            switch_interval=300, allow_grid_supplement=False,
+            dynamic_current=False,
+            current_entity=None,
+            min_current=0.0,
+            max_current=0.0,
+            ev_soc_entity=None,
+            ev_connected_entity=None,
+            is_big_consumer=False,
+            battery_max_discharge_override=None,
+            on_only=False,
+            min_daily_runtime=None,
+            max_daily_runtime=None,
+            schedule_deadline=None,
+            switch_interval=300,
+            allow_grid_supplement=False,
             max_grid_power=None,
         )
 
@@ -162,7 +221,8 @@ class TestRuntimeCounting:
         cycle_seconds = 30.0
 
         power_for_energy = (
-            current_power if current_power > 0
+            current_power
+            if current_power > 0
             else (0.0 if config.actual_power_entity else config.nominal_power)
         )
         energy_delta = (power_for_energy * cycle_seconds) / 3600 / 1000

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -4,28 +4,21 @@ Each test sets up realistic conditions and verifies the system makes correct
 decisions, exercising the complete optimizer flow:
   sensors -> optimizer -> decisions
 """
+
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 
-import pytest
 
 from custom_components.pv_excess_control.models import (
     Action,
-    ApplianceConfig,
-    ApplianceState,
-    BatteryDischargeAction,
     BatteryStrategy,
     BatteryTarget,
-    ControlDecision,
     Plan,
     PlanEntry,
     PlanReason,
-    PowerState,
-    TariffInfo,
     TariffWindow,
 )
-from custom_components.pv_excess_control.optimizer import Optimizer
 
 # Import shared helpers from the unit-level test module
 from tests.test_optimizer import (
@@ -42,6 +35,7 @@ from tests.test_optimizer import (
 # ---------------------------------------------------------------------------
 # Scenario 1: Sunny Day
 # ---------------------------------------------------------------------------
+
 
 class TestSunnyDay:
     """PV producing 5kW, household load 1.5kW -> 3.5kW excess.
@@ -73,7 +67,9 @@ class TestSunnyDay:
         power = _make_power(excess=3500.0, pv=5000.0)
         history = [power] * 6
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), history, _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), history, _make_tariff()
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
 
         # EV charger gets the 3kW (highest priority)
@@ -104,7 +100,9 @@ class TestSunnyDay:
         ]
         power = _make_power(excess=3500.0, pv=5000.0)
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), [power], _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), [power], _make_tariff()
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
 
         assert decisions["ev"].action == Action.ON
@@ -127,7 +125,9 @@ class TestSunnyDay:
         # 3000+200 + 2000+200 + 1000+200 = 6600W needed
         power = _make_power(excess=7000.0, pv=8500.0)
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), [power], _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), [power], _make_tariff()
+        )
         decisions = {d.appliance_id: d for d in result.decisions}
 
         assert decisions["ev"].action == Action.ON
@@ -138,6 +138,7 @@ class TestSunnyDay:
 # ---------------------------------------------------------------------------
 # Scenario 2: Cloudy Day (Hysteresis)
 # ---------------------------------------------------------------------------
+
 
 class TestCloudyDay:
     """Excess oscillating: history [500, -20, 300, -30, 200, -10] watts.
@@ -164,7 +165,9 @@ class TestCloudyDay:
         # Current reading is mildly negative
         power = _make_power(excess=-10)
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), history, _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), history, _make_tariff()
+        )
 
         assert len(result.decisions) == 1
         decision = result.decisions[0]
@@ -190,7 +193,9 @@ class TestCloudyDay:
         ]
         power = _make_power(excess=-350)
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), history, _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), history, _make_tariff()
+        )
 
         assert len(result.decisions) == 1
         assert result.decisions[0].action == Action.OFF, (
@@ -229,7 +234,9 @@ class TestCloudyDay:
         ]
         power = _make_power(excess=-200)
 
-        result = optimizer.optimize(power, appliances, states, _empty_plan(), history, _make_tariff())
+        result = optimizer.optimize(
+            power, appliances, states, _empty_plan(), history, _make_tariff()
+        )
 
         # New behavior: instant_budget = -200 < off_threshold (-50) → shed fires.
         assert result.decisions[0].action == Action.OFF
@@ -239,6 +246,7 @@ class TestCloudyDay:
 # ---------------------------------------------------------------------------
 # Scenario 3: Cheap Night Tariff
 # ---------------------------------------------------------------------------
+
 
 class TestCheapNightTariff:
     """No solar (excess=0), cheap tariff below threshold.
@@ -276,7 +284,10 @@ class TestCheapNightTariff:
             f"Appliance should be ON from grid supplement during cheap tariff but got {decision.action}. "
             f"Reason: {decision.reason}"
         )
-        assert "grid supplement" in decision.reason.lower() or "grid" in decision.reason.lower()
+        assert (
+            "grid supplement" in decision.reason.lower()
+            or "grid" in decision.reason.lower()
+        )
 
     def test_expensive_tariff_with_no_excess_stays_idle(self):
         """Expensive tariff, no solar: grid supplement does NOT activate appliance."""
@@ -306,6 +317,7 @@ class TestCheapNightTariff:
 # ---------------------------------------------------------------------------
 # Scenario 4: EV Deadline (plan entry with DEADLINE reason)
 # ---------------------------------------------------------------------------
+
 
 class TestEVDeadline:
     """Plan has a deadline entry for the EV charger approaching.
@@ -339,7 +351,7 @@ class TestEVDeadline:
             entries=[entry],
             battery_target=BatteryTarget(
                 target_soc=90.0,
-                target_time=datetime(2026, 3, 23, 7, 0, tzinfo=timezone.utc),
+                target_time=datetime(2026, 3, 23, 7, 0, tzinfo=UTC),
                 strategy=BatteryStrategy.BALANCED,
             ),
             confidence=0.9,
@@ -404,6 +416,7 @@ class TestEVDeadline:
 # ---------------------------------------------------------------------------
 # Scenario 5: Export Limit
 # ---------------------------------------------------------------------------
+
 
 class TestExportLimit:
     """PV producing 6kW, load 1kW -> excess 5kW.
@@ -484,6 +497,7 @@ class TestExportLimit:
 # ---------------------------------------------------------------------------
 # Scenario 6: EV Disconnected
 # ---------------------------------------------------------------------------
+
 
 class TestEVDisconnected:
     """Plenty of excess but EV is not plugged in.
@@ -575,6 +589,7 @@ class TestEVDisconnected:
 # ---------------------------------------------------------------------------
 # Scenario 7: Big Consumer Battery Protection
 # ---------------------------------------------------------------------------
+
 
 class TestBigConsumerBatteryProtection:
     """Two big consumers both active.
@@ -710,6 +725,7 @@ class TestBigConsumerBatteryProtection:
 # ---------------------------------------------------------------------------
 # Scenario 8: High Feed-In Tariff
 # ---------------------------------------------------------------------------
+
 
 class TestHighFeedInTariff:
     """2kW excess, 1kW appliance with allow_grid_supplement.

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,12 +3,12 @@
 Uses standard unittest.mock (no pytest-homeassistant-custom-component).
 Validates entity metadata, value reading, and graceful handling of missing data.
 """
+
 from __future__ import annotations
 
-import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, UTC
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,7 +52,7 @@ def _make_power_state(excess_power: float = 500.0) -> PowerState:
         battery_soc=80.0,
         battery_power=None,
         ev_soc=None,
-        timestamp=datetime.now(tz=timezone.utc),
+        timestamp=datetime.now(tz=UTC),
     )
 
 
@@ -76,19 +76,21 @@ def _make_appliance_state(
 
 def _make_plan(confidence: float = 0.85) -> Plan:
     return Plan(
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=datetime.now(tz=UTC),
         horizon=timedelta(hours=24),
         entries=[],
         battery_target=BatteryTarget(
             target_soc=100.0,
-            target_time=datetime.now(tz=timezone.utc) + timedelta(hours=8),
+            target_time=datetime.now(tz=UTC) + timedelta(hours=8),
             strategy=BatteryStrategy.BALANCED,
         ),
         confidence=confidence,
     )
 
 
-def _make_control_decision(appliance_id: str = "sub_1", reason: str = "excess available") -> ControlDecision:
+def _make_control_decision(
+    appliance_id: str = "sub_1", reason: str = "excess available"
+) -> ControlDecision:
     return ControlDecision(
         appliance_id=appliance_id,
         action=Action.ON,
@@ -207,7 +209,9 @@ class TestSensorSetup:
 
         await async_setup_entry(hass, config_entry, capture)
 
-        appliance_names = [e._attr_name for e in added_entities if "Solar Charger" in e._attr_name]
+        appliance_names = [
+            e._attr_name for e in added_entities if "Solar Charger" in e._attr_name
+        ]
         assert len(appliance_names) == 5
         assert "Solar Charger Power" in appliance_names
         assert "Solar Charger Runtime Today" in appliance_names
@@ -400,7 +404,9 @@ class TestApplianceSensors:
 
     def test_appliance_status_sensor_value(self):
         """Status sensor shows decision reason for the appliance."""
-        decision = _make_control_decision(appliance_id="sub_1", reason="excess available")
+        decision = _make_control_decision(
+            appliance_id="sub_1", reason="excess available"
+        )
         data = _make_coordinator_data(control_decisions=[decision])
         coord = _make_coordinator(data=data)
 
@@ -438,8 +444,12 @@ class TestApplianceSensors:
         """Appliance sensors return None when coordinator data is None."""
         coord = _make_coordinator(data=None)
 
-        for sensor_cls in [PvAppliancePowerSensor, PvApplianceRuntimeSensor,
-                           PvApplianceEnergySensor, PvApplianceStatusSensor]:
+        for sensor_cls in [
+            PvAppliancePowerSensor,
+            PvApplianceRuntimeSensor,
+            PvApplianceEnergySensor,
+            PvApplianceStatusSensor,
+        ]:
             sensor = sensor_cls(coord, "sub_1", "Heat Pump")
             assert sensor.native_value is None
 

--- a/tests/test_status_formatter.py
+++ b/tests/test_status_formatter.py
@@ -1,9 +1,30 @@
 """Tests for the status_formatter module."""
+
 from __future__ import annotations
 
 import pytest
 
+from datetime import datetime, timedelta
+
 from custom_components.pv_excess_control.status_formatter import format_duration
+from custom_components.pv_excess_control.status_formatter import format_status
+
+from custom_components.pv_excess_control.const import Action
+from custom_components.pv_excess_control.const import PlanReason
+
+from custom_components.pv_excess_control.models import (
+    ApplianceConfig,
+    ApplianceState,
+    BatteryDischargeAction,
+    ControlDecision,
+    BatteryStrategy,
+    BatteryTarget,
+    Plan,
+    PlanEntry,
+    TariffWindow,
+)
+
+from dataclasses import FrozenInstanceError
 
 
 class TestFormatDuration:
@@ -23,12 +44,12 @@ class TestFormatDuration:
             (599, "9min 59s"),
             (600, "10min"),
             (1800, "30min"),
-            (1829, "30min"),   # seconds dropped above the 10-minute boundary
+            (1829, "30min"),  # seconds dropped above the 10-minute boundary
             (3599, "59min"),
             (3600, "1h"),
             (3660, "1h 1min"),
             (7200, "2h"),
-            (7230, "2h"),      # 30s rounds to 0min → suppressed
+            (7230, "2h"),  # 30s rounds to 0min → suppressed
             (7260, "2h 1min"),
         ],
     )
@@ -40,7 +61,6 @@ class TestFormattedStatus:
     """FormattedStatus is a frozen dataclass holding the composed result."""
 
     def test_all_fields_defaultable(self) -> None:
-        from datetime import datetime
 
         from custom_components.pv_excess_control.status_formatter import FormattedStatus
 
@@ -69,25 +89,18 @@ class TestFormattedStatus:
         from custom_components.pv_excess_control.status_formatter import FormattedStatus
 
         fs = FormattedStatus(
-            text="x", action="on", overrides_plan=False,
-            cooldown_seconds_remaining=None, switch_deferred=False,
-            headroom_watts=None, plan_action=None,
-            plan_window_start=None, plan_window_end=None,
+            text="x",
+            action="on",
+            overrides_plan=False,
+            cooldown_seconds_remaining=None,
+            switch_deferred=False,
+            headroom_watts=None,
+            plan_action=None,
+            plan_window_start=None,
+            plan_window_end=None,
         )
-        with pytest.raises(Exception):
+        with pytest.raises(FrozenInstanceError):
             fs.text = "mutated"  # type: ignore[misc]
-
-
-from datetime import datetime, timedelta
-
-from custom_components.pv_excess_control.const import Action
-from custom_components.pv_excess_control.models import (
-    ApplianceConfig,
-    ApplianceState,
-    BatteryDischargeAction,
-    ControlDecision,
-)
-from custom_components.pv_excess_control.status_formatter import format_status
 
 
 def _make_config(
@@ -176,15 +189,16 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=10),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
             now=self.NOW,
         )
         assert fs.text == (
-            "Excess available (2100W >= 1800W needed) "
-            "(switch deferred - 50s cooldown)"
+            "Excess available (2100W >= 1800W needed) (switch deferred - 50s cooldown)"
         )
         assert fs.switch_deferred is True
         assert fs.cooldown_seconds_remaining == 50
@@ -198,7 +212,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=43),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -216,7 +232,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=10),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -233,7 +251,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=120),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -247,7 +267,9 @@ class TestFormatStatusCooldown:
         decision = _make_decision(action=Action.ON)
         state = _make_state(is_on=False, last_state_change=None)
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -271,7 +293,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=5),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -288,7 +312,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=10),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -304,7 +330,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=10),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -323,7 +351,9 @@ class TestFormatStatusCooldown:
             last_state_change=self.NOW - timedelta(seconds=100),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=600,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -393,7 +423,9 @@ class TestFormatStatusBatterySoftLimit:
             should_limit=True, max_discharge_watts=1500.0
         )
         fs = format_status(
-            decision, state, config,
+            decision,
+            state,
+            config,
             switch_interval=300,
             battery_action=battery_action,
             plan=None,
@@ -406,7 +438,9 @@ class TestFormatStatusBatterySoftLimit:
     def test_big_consumer_no_limit_no_suffix(self) -> None:
         decision = _make_decision(reason="Staying on (2300W drawn)")
         fs = format_status(
-            decision, _make_state(), _make_config(is_big_consumer=True),
+            decision,
+            _make_state(),
+            _make_config(is_big_consumer=True),
             switch_interval=300,
             battery_action=BatteryDischargeAction(should_limit=False),
             plan=None,
@@ -420,7 +454,9 @@ class TestFormatStatusBatterySoftLimit:
             should_limit=True, max_discharge_watts=1500.0
         )
         fs = format_status(
-            decision, _make_state(), _make_config(is_big_consumer=False),
+            decision,
+            _make_state(),
+            _make_config(is_big_consumer=False),
             switch_interval=300,
             battery_action=battery_action,
             plan=None,
@@ -437,7 +473,9 @@ class TestFormatStatusBatterySoftLimit:
             should_limit=True, max_discharge_watts=0.0
         )
         fs = format_status(
-            decision, _make_state(), _make_config(is_big_consumer=True),
+            decision,
+            _make_state(),
+            _make_config(is_big_consumer=True),
             switch_interval=300,
             battery_action=battery_action,
             plan=None,
@@ -454,23 +492,15 @@ class TestFormatStatusBatterySoftLimit:
             should_limit=True, max_discharge_watts=None
         )
         fs = format_status(
-            decision, _make_state(), _make_config(is_big_consumer=True),
+            decision,
+            _make_state(),
+            _make_config(is_big_consumer=True),
             switch_interval=300,
             battery_action=battery_action,
             plan=None,
             now=self.NOW,
         )
         assert "[battery discharge" not in fs.text
-
-
-from custom_components.pv_excess_control.models import (
-    BatteryStrategy,
-    BatteryTarget,
-    Plan,
-    PlanEntry,
-    TariffWindow,
-)
-from custom_components.pv_excess_control.const import PlanReason
 
 
 def _make_plan(entries: list[PlanEntry]) -> Plan:
@@ -526,7 +556,9 @@ class TestFormatStatusPlanDeviation:
             overrides_plan=True,
         )
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
@@ -545,7 +577,9 @@ class TestFormatStatusPlanDeviation:
         plan = _make_plan([])
         decision = _make_decision(reason="Manual override active", overrides_plan=True)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
@@ -560,7 +594,9 @@ class TestFormatStatusPlanDeviation:
     def test_overrides_plan_with_no_plan_falls_back(self) -> None:
         decision = _make_decision(reason="Manual override active", overrides_plan=True)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -580,15 +616,15 @@ class TestFormatStatusPlanDeviation:
             overrides_plan=True,
         )
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
             now=self.NOW,
         )
-        assert fs.text == (
-            "Excess available (2100W >= 1800W needed) [overrides plan]"
-        )
+        assert fs.text == ("Excess available (2100W >= 1800W needed) [overrides plan]")
 
     def test_plan_entry_for_different_appliance_no_match(self) -> None:
         entry = _make_plan_entry(
@@ -603,7 +639,9 @@ class TestFormatStatusPlanDeviation:
             overrides_plan=True,
         )
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
@@ -614,7 +652,9 @@ class TestFormatStatusPlanDeviation:
     def test_overrides_plan_false_no_suffix(self) -> None:
         decision = _make_decision(reason="Excess available", overrides_plan=False)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -640,7 +680,9 @@ class TestFormatStatusPlanDeviation:
             overrides_plan=True,
         )
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
@@ -668,7 +710,9 @@ class TestFormatStatusPlanDeviation:
             overrides_plan=True,
         )
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=plan,
@@ -706,7 +750,9 @@ class TestFormatStatusCombined:
         )
         plan = _make_plan([entry])
         fs = format_status(
-            decision, state, config,
+            decision,
+            state,
+            config,
             switch_interval=60,
             battery_action=battery_action,
             plan=plan,
@@ -725,7 +771,9 @@ class TestFormatStatusCombined:
         long_reason = "x" * 300
         decision = _make_decision(reason=long_reason)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -739,7 +787,9 @@ class TestFormatStatusCombined:
         reason = "x" * 255
         decision = _make_decision(reason=reason)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -753,7 +803,9 @@ class TestFormatStatusCombined:
         reason = "x" * 254
         decision = _make_decision(reason=reason)
         fs = format_status(
-            decision, _make_state(), _make_config(),
+            decision,
+            _make_state(),
+            _make_config(),
             switch_interval=300,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -775,7 +827,9 @@ class TestFormatStatusCombined:
             last_state_change=self.NOW - timedelta(seconds=10),
         )
         fs = format_status(
-            decision, state, _make_config(),
+            decision,
+            state,
+            _make_config(),
             switch_interval=60,
             battery_action=_NO_BATTERY_LIMIT,
             plan=None,
@@ -814,7 +868,9 @@ class TestFormatStatusCombined:
         )
         plan = _make_plan([entry])
         fs = format_status(
-            decision, state, config,
+            decision,
+            state,
+            config,
             switch_interval=60,
             battery_action=battery_action,
             plan=plan,

--- a/tests/test_status_sensor.py
+++ b/tests/test_status_sensor.py
@@ -1,4 +1,5 @@
 """Integration tests for PvApplianceStatusSensor wiring to the formatter."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -16,17 +17,28 @@ from custom_components.pv_excess_control.sensor import PvApplianceStatusSensor
 
 def _make_config() -> ApplianceConfig:
     return ApplianceConfig(
-        id="sub123", name="Test Heater", entity_id="switch.heater",
-        priority=100, phases=1, nominal_power=2000.0, actual_power_entity=None,
-        dynamic_current=False, current_entity=None,
-        min_current=6.0, max_current=16.0,
-        ev_soc_entity=None, ev_connected_entity=None,
-        is_big_consumer=False, battery_max_discharge_override=None,
+        id="sub123",
+        name="Test Heater",
+        entity_id="switch.heater",
+        priority=100,
+        phases=1,
+        nominal_power=2000.0,
+        actual_power_entity=None,
+        dynamic_current=False,
+        current_entity=None,
+        min_current=6.0,
+        max_current=16.0,
+        ev_soc_entity=None,
+        ev_connected_entity=None,
+        is_big_consumer=False,
+        battery_max_discharge_override=None,
         on_only=False,
-        min_daily_runtime=None, max_daily_runtime=None,
+        min_daily_runtime=None,
+        max_daily_runtime=None,
         schedule_deadline=None,
         switch_interval=300,
-        allow_grid_supplement=False, max_grid_power=None,
+        allow_grid_supplement=False,
+        max_grid_power=None,
     )
 
 
@@ -202,7 +214,7 @@ class TestStatusSensorNativeValue:
             cooldown_n = attrs["cooldown_seconds_remaining"]
             assert f"{cooldown_n}s cooldown" in text or (
                 # _format_duration may render as "Xmin Ys" for >60s
-                f"cooldown" in text
+                "cooldown" in text
             )
 
     def test_fallback_when_state_missing(self) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for ForceChargeSwitch snappy engage/disengage behaviour."""
+
 from __future__ import annotations
 
 import pytest
@@ -15,7 +16,10 @@ from custom_components.pv_excess_control.const import (
 
 @pytest.mark.asyncio
 async def test_force_charge_switch_on_calls_engage_immediately(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     """Flipping the switch ON triggers engage immediately, not on the next coordinator cycle."""
     from custom_components.pv_excess_control.switch import ForceChargeSwitch
@@ -42,7 +46,10 @@ async def test_force_charge_switch_on_calls_engage_immediately(
 
 @pytest.mark.asyncio
 async def test_force_charge_switch_off_calls_disengage_immediately_when_not_auto_should_engage(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     """When auto_should_engage_now is False, flipping switch OFF disengages immediately."""
     from custom_components.pv_excess_control.switch import ForceChargeSwitch
@@ -75,7 +82,10 @@ async def test_force_charge_switch_off_calls_disengage_immediately_when_not_auto
 
 @pytest.mark.asyncio
 async def test_force_charge_switch_off_keeps_engaged_when_auto_should_engage_now(
-    coordinator_factory, mock_inverter_controller, mock_tariff_at, mock_power_state_with_soc,
+    coordinator_factory,
+    mock_inverter_controller,
+    mock_tariff_at,
+    mock_power_state_with_soc,
 ):
     """When auto_should_engage_now is True (cheap window, SoC below target), switch OFF
     leaves the inverter engaged via the auto path."""
@@ -106,7 +116,9 @@ async def test_force_charge_switch_off_keeps_engaged_when_auto_should_engage_now
 
 
 @pytest.mark.asyncio
-async def test_force_charge_switch_no_inverter_configured_no_engage_call(coordinator_factory):
+async def test_force_charge_switch_no_inverter_configured_no_engage_call(
+    coordinator_factory,
+):
     """No inverter wired — switch still works (sheds appliances), no engage/disengage calls."""
     from custom_components.pv_excess_control.switch import ForceChargeSwitch
 


### PR DESCRIPTION
Summary

This PR combines several improvements around restart resilience, appliance configuration, and dynamic EV charging.

The main functional changes are:

persist daily appliance statistics across Home Assistant restarts
add and correctly propagate the global on_threshold configuration
fix optimizer budget allocation for disconnected EVs while manual override is active
add regression coverage for the EV budgeting behavior
introduce a pre-commit setup and apply the resulting code/style cleanup
Changelog
Added
Added persistence for daily appliance state so runtime, activations, and energy today survive Home Assistant restarts.
Daily state is restored before the coordinator performs its first refresh.
Daily state is saved when the config entry is unloaded and after the midnight reset.
Added global on_threshold configuration to the config flow.
Added pre-commit configuration with Ruff, codespell, yamllint, Prettier, and additional manual type-checking/typing hooks.
Added a regression test for disconnected EVs using manual override.
Fixed
Fixed the global on_threshold not being passed to individual appliance configurations.
An appliance-specific on_threshold still takes precedence.
The global value is now used as fallback when no appliance-specific value is configured.
Fixed dynamic-current/manual-override power budgeting when an EV is explicitly disconnected.
Manual override remains active and the configured maximum current is still pre-set.
When ev_connected explicitly reports False, the appliance no longer reserves its theoretical maximum charging power.
This prevents a disconnected wallbox from consuming optimizer budget and incorrectly blocking lower-priority appliances.
Prevented runtime-only state updates from unnecessarily triggering a full integration reload.
Changed
Improved configuration descriptions and examples for pricing and nominal power settings.
Applied Ruff/pre-commit formatting and lint cleanup throughout the codebase, tests, documentation, and YAML files.
Performed several small code-quality refactors identified by the new pre-commit checks.
EV override example

Before this change, a disconnected 1-phase wallbox configured for 16 A manual override could still reserve approximately 3680 W of optimizer budget even though no vehicle was connected and actual consumption was 0 W.

This could result in another appliance receiving a negative available-power budget and being prevented from starting.

With this change:

EV connected: normal manual-override power budgeting applies
EV explicitly disconnected: manual override stays prepared, but 0 W is reserved
EV connection state unavailable/unknown: existing conservative behavior is preserved
Related

Closes #51

Includes the DEFAULT_ON_THRESHOLD config-flow changes previously proposed in #52.

Review note

A significant portion of the overall diff consists of mechanical formatting and lint-related changes caused by introducing the pre-commit configuration. The primary functional changes are the daily-state persistence, global on_threshold handling, and EV override budgeting fix.